### PR TITLE
Add Publish TechDocs workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,0 @@
-### What does this PR do?
-
-(Please set a descriptive PR title. Use this space for additional explanations.)
-
-### Should this change be mentioned in the changelog?
-
-- [ ] CHANGELOG.md has been updated

--- a/.github/workflows/publish-techdocs.yaml
+++ b/.github/workflows/publish-techdocs.yaml
@@ -1,0 +1,160 @@
+# This workflow publishes documentation from a repository
+# (README.md, docs/ folder content, and helm chart README.md files)
+# for use in Backstage portals. Only effective on public repos.
+#
+# General info about Backstage TechDocs:
+# https://backstage.io/docs/features/techdocs/
+
+name: Publish TechDocs
+
+# Supposed to work on pushes to the default branch only,
+# and only if relevant files were changed.
+on:
+  workflow_call:
+    secrets:
+      aws_access_key_id:
+        required: true
+      aws_secret_access_key:
+        required: true
+
+jobs:
+  publish:
+    if: github.event.repository.visibility == 'public'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: Set up NodeJS
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '22'
+
+      - name: Clone source repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Cache dependencies
+        id: cache-npm
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        env:
+          cache-name: cache-node-modules
+        with:
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          path:
+            ./node_modules
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+      
+      - if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
+        name: List the state of node modules
+        continue-on-error: true
+        run: npm list
+      
+      - name: Install techdocs-cli
+        run: npm install @techdocs/cli
+
+      - name: Show techdocs-cli version
+        run: ./node_modules/@techdocs/cli/bin/techdocs-cli --version
+      
+      - name: Generate mkdocs configuration
+        id: generate_mkdocs_config
+        shell: python {0}
+        run: |
+          import os
+          import shutil
+
+          pwd = os.getcwd()
+          docspath = os.path.join(pwd, "docs")
+
+          output = "site_name: ${{ github.event.repository.name }}\n"
+          output += "docs_dir: ./docs\n"
+          output += "plugins:\n"
+          output += "  - techdocs-core\n"
+
+          os.makedirs(docspath, exist_ok=True)
+
+          # Dict of menu items
+          # Key is the relative path and value is the label (or None).
+          nav = {}
+
+          # Main README
+          if os.path.exists("README.md"):
+              print("Copying README.md to docs/_README.md", flush=True)
+              shutil.copyfile("README.md", os.path.join(docspath, "_README.md"))
+              nav["./_README.md"] = "Main README"
+
+          # Detect helm chart README files
+          helmpath = os.path.join(pwd, "helm")
+          if os.path.exists(helmpath):
+              print(f"Finding README.md files in Helm charts", flush=True)
+              for root, _, files in os.walk(helmpath):
+                  for f in sorted(files):
+                      if f == "README.md":
+                          abspath = os.path.join(root, f)
+                          relpath = abspath.removeprefix(helmpath)
+                          # Copy to docs folder
+                          new_filename = "_helm" + relpath.replace("/", "_")
+                          target_path = os.path.join(docspath, new_filename)
+                          print(f"Copying {abspath} to {target_path}", flush=True)
+                          shutil.copyfile(abspath, target_path)
+                          nav[f"./{new_filename}"] = f"Helm Chart {os.path.basename(os.path.dirname(abspath))}"
+
+          # Any other markdown in docs folder
+          print(f"Finding Markdown (*.md) files in {docspath}", flush=True)
+          for root, _, files in os.walk(docspath):
+              for f in sorted(files):
+                  if not f.endswith(".md"):
+                      continue
+                  abspath = os.path.join(root, f)
+                  relpath = "." + abspath.removeprefix(docspath)
+                  if relpath in nav:
+                      continue
+                  if relpath == "./README.md":
+                      nav[relpath] = "Docs Index"
+                  else:
+                      nav[relpath] = None # Title from content will be applied as label
+
+          if len(nav) == 0:
+              print("No markdown files found in docs folder. Exiting.")
+              with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+                  f.write("content_found=false\n")
+              exit(0)
+
+          output += "nav:\n"
+          for key in sorted(nav.keys()):
+              if nav[key] is None:
+                  output += f"  - '{key}'\n"
+              else:
+                  output += f"  - '{nav[key]}': '{key}'\n"
+
+          print("\nWriting mkdocs.yml with the following content:\n\n")
+          print(output)
+          print("\n")
+
+          with open("mkdocs.yml", "w") as f:
+              f.write(output)
+          
+          with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+              f.write("content_found=true\n")
+
+      
+      - if: ${{ steps.generate_mkdocs_config.outputs.content_found == 'true' }}
+        name: Generate documentation
+        run: |
+          mkdir $GITHUB_WORKSPACE/tmp-docs-output
+          $GITHUB_WORKSPACE/node_modules/@techdocs/cli/bin/techdocs-cli \
+            generate --verbose --output-dir=$GITHUB_WORKSPACE/tmp-docs-output
+      
+      - if: ${{ steps.generate_mkdocs_config.outputs.content_found == 'true' }}
+        name: Show output
+        run: ls -la $GITHUB_WORKSPACE/tmp-docs-output
+      
+      - if: ${{ steps.generate_mkdocs_config.outputs.content_found == 'true' }}
+        name: Publish
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_id }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_access_key }}
+          AWS_REGION: eu-central-1
+        run: |
+          $GITHUB_WORKSPACE/node_modules/@techdocs/cli/bin/techdocs-cli publish \
+            --publisher-type awsS3 \
+            --storage-name gs-backstage-techdocs-public \
+            --entity default/component/${{ github.event.repository.name }} \
+            --directory $GITHUB_WORKSPACE/tmp-docs-output

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# Github Workflows
+# GitHub Workflows
 
-Set of Github Workflows to use on GiantSwarm repositories.
+A repository of reusable workflows, intended for use in the `giantswrm` organization.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# GitHub Workflows
+# GitHub workflows
 
 A repository of reusable workflows, intended for use in the `giantswrm` organization.


### PR DESCRIPTION
Moves https://github.com/giantswarm/workflows-public/blob/main/.github/workflows/publish-techdocs.yaml into the new common place.

Also removes the PR template, as it's only purpose was the prompting for a changelog entry. Since we don't do releases here, changelog entries don't make sense.