### PR TITLE
Allow renovate to update binaries in workflows

### DIFF
--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -174,7 +174,8 @@ jobs:
       - name: Install architect
         uses: giantswarm/install-binary-action@c37eb401e5092993fc76d545030b1d1769e61237 # v3.0.0
         with:
-          binary: "architect"
+          binary: architect
+          # renovate: datasource=github-tags depName=giantswarm/architect versioning=loose
           version: "6.17.0"
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/renovate.json5
+++ b/renovate.json5
@@ -4,4 +4,17 @@
     // Base config - https://github.com/giantswarm/renovate-presets/blob/main/default.json5
     "github>giantswarm/renovate-presets:default.json5",
   ],
+  customManagers: [
+    {
+      description: 'Allow updating binaries in workflows installed via install-binary-action',
+      customType: 'regex',
+      fileMatch: [
+        '^\\.github/workflows/.*\\.yaml$',
+      ],
+      matchStrings: [
+        '# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\sversion:\\s(?<currentValue>\\S+)',
+      ],
+      versioningTemplate: '{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}',
+    },
+  ],
 }


### PR DESCRIPTION
This PR adds a regex manager configured to check for a certain comment type in workflows, and applies it in a place where architect is installed in a workflow.