### PR TITLE
Bump `github.com/marwan-at-work/mod/cmd/mod` to `v0.9.0`

### DIFF
--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -170,7 +170,7 @@ jobs:
     steps:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version: '=1.24.6'
+          go-version: '=1.25.1'
       - name: Install architect
         uses: giantswarm/install-binary-action@0797deb878056114fa54ee30c519f617716e8c69 # v3.1.1
         with:
@@ -230,7 +230,7 @@ jobs:
       - name: Bump go module defined in go.mod if needed
         run: |
           if [ "${{ needs.gather_facts.outputs.needs_major_bump }}" = true ] && test -f "go.mod"; then
-            go install github.com/marwan-at-work/mod/cmd/mod@v0.8.0
+            go install github.com/marwan-at-work/mod/cmd/mod@v0.9.0
             mod upgrade
           fi
       - name: Set up git identity


### PR DESCRIPTION
https://github.com/marwan-at-work/mod/pull/32 fixes the issue for go 1.25+. It is tagged as `v0.9.0` that we can use already.