### PR TITLE
Bump giantswarm/install-binary-action to v4.0.1

### DIFF
--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -191,7 +191,7 @@ jobs:
         with:
           go-version: '=1.26.2'
       - name: Install architect
-        uses: giantswarm/install-binary-action@c94c7adadeb14af4bdbdd601f9a6e7f69638134c # v4.0.0
+        uses: giantswarm/install-binary-action@952007edaee6637d91216e7001f79aff11e93228 # v4.0.1
         with:
           binary: architect
           # renovate: datasource=github-tags depName=giantswarm/architect

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -97,12 +97,12 @@ jobs:
       - gather_facts
     steps:
       - name: Install architect
-        uses: giantswarm/install-binary-action@c94c7adadeb14af4bdbdd601f9a6e7f69638134c # v4.0.0
+        uses: giantswarm/install-binary-action@952007edaee6637d91216e7001f79aff11e93228 # v4.0.1
         with:
           binary: "architect"
           version: "6.14.1"
       - name: Install semver
-        uses: giantswarm/install-binary-action@c94c7adadeb14af4bdbdd601f9a6e7f69638134c # v4.0.0
+        uses: giantswarm/install-binary-action@952007edaee6637d91216e7001f79aff11e93228 # v4.0.1
         with:
           binary: "semver"
           version: "3.2.0"
@@ -224,7 +224,7 @@ jobs:
     if: ${{ needs.gather_facts.outputs.version }}
     steps:
       - name: Install semver
-        uses: giantswarm/install-binary-action@c94c7adadeb14af4bdbdd601f9a6e7f69638134c # v4.0.0
+        uses: giantswarm/install-binary-action@952007edaee6637d91216e7001f79aff11e93228 # v4.0.1
         with:
           binary: "semver"
           version: "3.0.0"
@@ -302,7 +302,7 @@ jobs:
       - gather_facts
     steps:
       - name: Install architect
-        uses: giantswarm/install-binary-action@c94c7adadeb14af4bdbdd601f9a6e7f69638134c # v4.0.0
+        uses: giantswarm/install-binary-action@952007edaee6637d91216e7001f79aff11e93228 # v4.0.1
         with:
           binary: "architect"
           version: "6.14.1"

--- a/.github/workflows/helm-render-diff.yaml
+++ b/.github/workflows/helm-render-diff.yaml
@@ -53,7 +53,7 @@ jobs:
           version: ${{ env.helm_ver }}
       - run: which helm
       - name: install dyff
-        uses: giantswarm/install-binary-action@c94c7adadeb14af4bdbdd601f9a6e7f69638134c # v4.0.0
+        uses: giantswarm/install-binary-action@952007edaee6637d91216e7001f79aff11e93228 # v4.0.1
         with:
           binary: dyff
           download_url: "https://github.com/homeport/dyff/releases/download/v${version}/dyff_${version}_linux_amd64.tar.gz"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 however this project does not use Semantic Versioning and there are no releases.
 Instead this file uses a date-based structure.
 
+## 2026-04-17
+
+### Changed
+
+- Bump `giantswarm/install-binary-action` from `v4.0.0` to `v4.0.1` in `create-release`, `create-release-pr`, and `helm-render-diff` workflows to pick up the fix for the `mkdir: File exists` collision in pre-commit runs (see `giantswarm/install-binary-action#334`).
+
 ## 2026-04-15
 
 ### Added


### PR DESCRIPTION
## Summary

Bumps the pinned `giantswarm/install-binary-action` SHA from `v4.0.0` (`c94c7ada…`) to `v4.0.1` (`952007ed…`) in the reusable workflows that consumer repositories call via `zz_generated.*.yaml`.

## Why

v4.0.1 fixes the `mkdir: File exists` collision reported in `giantswarm/install-binary-action#334`, which was tripping pre-commit CI runs whenever the binary being installed (e.g. `helm`, `jq`) shared a name with a pre-existing file or directory in the workspace. The fix extracts archives into a unique directory under `RUNNER_TEMP` instead of the workspace root.

The companion change to `workflows/zz_generated.pre-commit.yaml` already landed in `giantswarm/github#5073`. This PR closes the remaining propagation gap: consumer repos reference the workflows in this repo as `@main`, so merging here makes the fix effective everywhere on the next run with zero devctl/align-files work.

## Changes

- `.github/workflows/create-release.yaml` — 4 pins bumped
- `.github/workflows/create-release-pr.yaml` — 1 pin bumped
- `.github/workflows/helm-render-diff.yaml` — 1 pin bumped
- `CHANGELOG.md` — new dated entry

## Test plan

- [ ] Confirm CI is green on this PR
- [ ] After merge, spot-check a consumer repo's next `zz_generated.create_release*.yaml` run to confirm the new SHA is pulled in

Made with [Cursor](https://cursor.com)