### PR TITLE
Fix interpretation of fetch-deep-gitlog-for-build input

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -314,7 +314,10 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ env.TAG }}
-          fetch-depth: ${{ inputs.fetch-deep-gitlog-for-build && 0 || 1 }}
+          # Strings ('0' / '1') are required because the GHA ternary idiom
+          # `cond && A || B` only works when A is truthy. The number `0`
+          # is falsy, so `cond && 0 || 1` always evaluates to `1`.
+          fetch-depth: ${{ inputs.fetch-deep-gitlog-for-build && '0' || '1' }}
       - name: Create ${{ matrix.platform }} package
         run: make package-${{ matrix.platform }}
       - name: Specify package file name based on platform

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 however this project does not use Semantic Versioning and there are no releases.
 Instead this file uses a date-based structure.
 
+## 2026-04-24
+
+- Fix interpretation of `fetch-deep-gitlog-for-build` input in `crteate-release` workflow, to allow for fetching git log.
+
 ## 2026-04-17
 
 ### Changed


### PR DESCRIPTION
This is supposed to fix the handling of `fetch-deep-gitlog-for-build`, which exists to build binaries with the full git commit history available. This is needed for `devctl` in particular.