### PR TITLE
fix(fix-vulnerabilities): change app-id to client-id

### DIFF
--- a/.github/workflows/fix-vulnerabilities.yaml
+++ b/.github/workflows/fix-vulnerabilities.yaml
@@ -74,7 +74,7 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          app-id: ${{ secrets.HERALD_APP_ID }}
+          client-id: ${{ secrets.HERALD_APP_ID }}
           private-key: ${{ secrets.HERALD_APP_KEY }}
 
       - name: Checkout code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 however this project does not use Semantic Versioning and there are no releases.
 Instead this file uses a date-based structure.
 
+## 2026-05-07
+
+- Change actions/create-github-app-token param `app-id` to `client-id` in fix-vulnerabilities workflow.
+
 ## 2026-04-24
 
 - Fix interpretation of `fetch-deep-gitlog-for-build` input in `crteate-release` workflow, to allow for fetching git log.


### PR DESCRIPTION
Adapts the workflow to mitigate these warnings:

<img width="591" height="62" alt="image" src="https://github.com/user-attachments/assets/a3f9525c-d752-4bf9-9bbe-23bcab4875fb" />


## Checklist

- I have updated the [CHANGELOG.md](../CHANGELOG.md) with a description of the change
