### PR TITLE
Rename HERALD_CLIENT_ID to HERALD_APP_ID in fix-vulnerabilities workflow

### DIFF
--- a/.github/workflows/fix-vulnerabilities.yaml
+++ b/.github/workflows/fix-vulnerabilities.yaml
@@ -12,7 +12,7 @@ on:
         default: "info"
         type: string
     secrets:
-      HERALD_CLIENT_ID:
+      HERALD_APP_ID:
         description: Client ID for create-github-app-token
         required: true
       HERALD_APP_KEY:
@@ -74,7 +74,7 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          client-id: ${{ secrets.HERALD_CLIENT_ID }}
+          client-id: ${{ secrets.HERALD_APP_ID }}
           private-key: ${{ secrets.HERALD_APP_KEY }}
 
       - name: Checkout code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 however this project does not use Semantic Versioning and there are no releases.
 Instead this file uses a date-based structure.
 
+## 2026-05-11
+
+### Fixed
+
+- Renamed `HERALD_CLIENT_ID` to `HERALD_APP_ID` in fix-vulnerabilities workflow to avoid a missing secret scenario in devctl generated files.
+
 ## 2026-05-07
 
 ### Changed


### PR DESCRIPTION
Towards: https://gigantic.slack.com/archives/C0ALXPMB1PW/p1778500520030199\?thread_ts\=1778492444.184879\&cid\=C0ALXPMB1PW