### PR TITLE
fix(js-dependency-audit): drop invalid --groups flag for yarn-classic

### DIFF
--- a/.github/workflows/js-dependency-audit.yaml
+++ b/.github/workflows/js-dependency-audit.yaml
@@ -132,7 +132,7 @@ jobs:
                 (cd "${dir}" && yarn npm audit --all --recursive --json) > "${raw}" 2> "${err}" || true
                 ;;
               yarn-classic)
-                (cd "${dir}" && yarn audit --json --groups dependencies,devDependencies) > "${raw}" 2> "${err}" || true
+                (cd "${dir}" && yarn audit --json) > "${raw}" 2> "${err}" || true
                 ;;
             esac
           }


### PR DESCRIPTION
## Summary

`yarn audit --json --groups dependencies,devDependencies` doesn't work for yarn v1: `--groups` is a space-separated multi-arg flag, so the comma-joined form is parsed as a single literal group name that doesn't exist, and the audit returns 0 advisories with `totalDependencies: 0`.

Dropping the flag uses yarn's default groups (`devDependencies,dependencies,optionalDependencies`), matching the original intent (audit prod + dev dependencies) and aligning with what `npm`, `pnpm`, and `yarn-berry` already do here.

## How it surfaced

`giantswarm/happa#4746` is a Renovate PR upgrading `mermaid` to fix several CVEs. The audit comment showed:

> 0 added · 0 removed · 0 total

…with no "Full current vulnerability list" details block. Both audit runs (head and base) produced empty findings, so the delta was 0/0/0 and the renderer correctly skipped the empty list.

## Verification on happa (yarn-classic)

| Invocation | advisories | totalDependencies |
|---|---|---|
| `yarn audit --json --groups dependencies,devDependencies` (before) | 0 | 0 |
| `yarn audit --json --groups dependencies devDependencies` (space, valid) | 29 | 612 |
| `yarn audit --json` (default, this PR) | 342 | 3194 |

Default groups also include `optionalDependencies`, which is consistent with what `npm audit` reports.

## Test plan

- [ ] Re-run the workflow on `giantswarm/happa#4746` (or any yarn-classic caller) and confirm the comment now reports a non-zero current total and renders the details block.
- [ ] Spot-check that npm / pnpm / yarn-berry callers are unaffected.