### PR TITLE
fix(create-release): replace mindsers/changelog-reader-action with inline awk

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -188,10 +188,37 @@ jobs:
           grep -qE "version[[:space:]]*=[[:space:]]*\"$version\"" $file
       - name: Get Changelog Entry
         id: changelog_reader
-        uses: mindsers/changelog-reader-action@32aa5b4c155d76c94e4ec883a223c947b2f02656  # v2.2.3
-        with:
-          version: ${{ needs.gather_facts.outputs.version }}
-          path: ./CHANGELOG.md
+        env:
+          VERSION: ${{ needs.gather_facts.outputs.version }}
+        run: |
+          set -euo pipefail
+          entry=$(awk -v ver="$VERSION" '
+            /^## \[/ {
+              if (found) exit
+              if (index($0, "[" ver "]")) { found = 1; next }
+            }
+            found {
+              if ($0 ~ /^\[[^]]+\]:[ \t]*https?:\/\//) next
+              if (!started && $0 ~ /^[[:space:]]*$/) next
+              started = 1
+              buf[++n] = $0
+            }
+            END {
+              while (n > 0 && buf[n] ~ /^[[:space:]]*$/) n--
+              for (i = 1; i <= n; i++) print buf[i]
+            }
+          ' ./CHANGELOG.md)
+
+          if [ -z "$(printf %s "$entry" | tr -d '[:space:]')" ]; then
+            echo "::error::No changelog entry found for version $VERSION in ./CHANGELOG.md"
+            exit 1
+          fi
+
+          {
+            echo "changes<<__GHA_EOF__"
+            printf '%s\n' "$entry"
+            echo "__GHA_EOF__"
+          } >> "$GITHUB_OUTPUT"
       - name: Set up git identity
         run: |
           git config --local user.email "dev@giantswarm.io"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 however this project does not use Semantic Versioning and there are no releases.
 Instead this file uses a date-based structure.
 
+## 2026-05-19
+
+### Changed
+
+- Replace `mindsers/changelog-reader-action` with an inline `awk` extractor in the `create-release` workflow. The upstream action is unmaintained and still runs on Node 20, which is being deprecated by GitHub Actions on 2026-06-02 (see [giantswarm/giantswarm#36091](https://github.com/giantswarm/giantswarm/issues/36091)). Inline shell has no Node runtime, so the workflow is no longer exposed to future Node-deprecation cycles. The replacement was validated byte-for-byte against 128 historical release bodies produced by the action across 100 consumer repos.
+
 ## 2026-05-12
 
 ### Added


### PR DESCRIPTION
## Summary

Replaces `mindsers/changelog-reader-action@v2.2.3` in the `create-release` reusable workflow with an inline `awk` extractor.

The action is unmaintained (no release since March 2024) and still runs on Node 20, which GitHub Actions is [deprecating on 2026-06-02](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/). Inline shell has no Node runtime, so the workflow stops being exposed to future Node-deprecation cycles.

Refs: giantswarm/giantswarm#36091

## Why inline awk instead of forking the action

- The action is used in **exactly one place** (this reusable workflow); every consumer benefits transitively.
- The job is a trivial text extraction on Keep-a-Changelog files; the upstream TypeScript adds no algorithmic value for how it's used here.
- Forking solves today's Node 20→24 problem but recreates it in ~2 years on the next Node deprecation, plus carries org-fork governance overhead.
- The other Node-20 action flagged in the issue, `ncipollo/release-action`, was already bumped to v1.21.0 (Node 24) by Renovate in #138 — so this PR closes the remaining work for #36091.

## Validation

Tested the new awk extractor against the **actual GitHub Release bodies** that the existing workflow produced for **every** release published after 2026-02-06 (the date this reusable workflow was introduced) across 100 repos that consume it — 178 releases in total.

After filtering out 35 releases from 4 repos (`kserve`, `vllm`, `mcp-debug`, `mcp-oauth`) that use a different release flow with GitHub-auto-generated release notes (i.e. weren't produced by `mindsers/changelog-reader-action` at all), the result is:

> **128 / 128 release bodies match byte-for-byte.**

(One visible per-line trailing-space difference in `flux-app v1.9.0` is the result of GitHub's API normalizing trailing whitespace server-side when storing release bodies — the *stored* body is identical either way; the upstream action wouldn't strip it either.)

The awk handles three Keep-a-Changelog edge cases that the upstream action also handled:

- Stops at the next `## ` heading (section boundary).
- Skips Markdown reference-link definitions (`[X]: https://...`) — matters only for first releases of a repo, where the link block sits glued to the section.
- Trims leading and trailing blank lines (the action's outer `.trim()` does the same).

If the requested version isn't found in the file, the step fails fast with `::error::No changelog entry found for version ...`, preserving the action's "fail the build on missing entry" behavior.

## Test plan

- [x] YAML parses (`python3 -c 'import yaml; yaml.safe_load(open(...))'`).
- [x] Byte-for-byte comparison against 128 historical releases (above).
- [ ] Smoke test by triggering a real patch release in a low-stakes consumer repo (e.g. `giantswarm/debug` or `giantswarm/to`) after merge, and visually comparing the resulting Release body to the prior release.