### PR TITLE
feat: add semantic-pull-request reusable workflow

### DIFF
--- a/.github/workflows/semantic-pull-request.yaml
+++ b/.github/workflows/semantic-pull-request.yaml
@@ -1,0 +1,18 @@
+name: Semantic Pull Request
+
+on:
+  workflow_call: {}
+
+permissions: {}
+
+jobs:
+  semantic-pull-request:
+    name: Validate PR title
+    runs-on: ubuntu-24.04
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Validate PR title follows Conventional Commits
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 however this project does not use Semantic Versioning and there are no releases.
 Instead this file uses a date-based structure.
 
+## 2026-05-20
+
+### Added
+
+- Add reusable workflow `semantic-pull-request.yaml`. Validates that a pull request title follows Conventional Commits, using `amannn/action-semantic-pull-request`'s default type set (sourced from [`commitizen/conventional-commit-types`](https://github.com/commitizen/conventional-commit-types): `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`). Callers trigger it on `pull_request` with `types: [opened, edited, synchronize]`.
+
 ## 2026-05-19
 
 ### Changed


### PR DESCRIPTION
## Summary

Adds a reusable workflow that validates pull request titles against [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/), using [`amannn/action-semantic-pull-request`](https://github.com/amannn/action-semantic-pull-request) with its default type set sourced from [`commitizen/conventional-commit-types`](https://github.com/commitizen/conventional-commit-types): `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`.

## Usage from a caller

```yaml
on:
  pull_request:
    types: [opened, edited, synchronize]

permissions: {}

jobs:
  semantic-pull-request:
    uses: giantswarm/github-workflows/.github/workflows/semantic-pull-request.yaml@main
    permissions:
      pull-requests: read
```

## Notes

- The action only needs `pull-requests: read`; the implicit `GITHUB_TOKEN` passes through to a `workflow_call` caller automatically.
- The matching devctl wrapper that generates the caller workflow in every repo is at giantswarm/devctl#TBD — must merge **after** this PR.
- Action pinned to commit SHA (v6.1.1). Renovate's `github-actions` manager + `helpers:pinGitHubActionDigests` keep it up to date.