### PR TITLE
feat(validate-changelog): accept ### Security and enforce Keep a Changelog H3 set

### DIFF
--- a/.github/workflows/validate-changelog.yaml
+++ b/.github/workflows/validate-changelog.yaml
@@ -120,10 +120,27 @@ jobs:
 
           echo "Found changelog section for version $version"
 
-          # Check if there are any ### headers (Added, Changed, Deprecated, Removed, Fixed, Security)
-          subsection_count=$(echo "$changelog_section" | grep -c "^### " || true)
+          # Accepted Keep a Changelog H3 sections (https://keepachangelog.com/en/1.1.0/).
+          accepted_pattern='^### (Added|Changed|Deprecated|Removed|Fixed|Security)[[:space:]]*$'
 
-          if [ "$subsection_count" -eq 0 ]; then
+          all_headers=$(echo "$changelog_section" | grep -E "^### " || true)
+          accepted_headers=$(echo "$all_headers" | grep -E "$accepted_pattern" || true)
+          unknown_headers=$(echo "$all_headers" | grep -Ev "$accepted_pattern" || true)
+
+          accepted_count=0
+          if [ -n "$accepted_headers" ]; then
+            accepted_count=$(echo "$accepted_headers" | wc -l)
+          fi
+
+          if [ -n "$unknown_headers" ]; then
+            echo "::error title=Unknown Changelog Section::Found H3 headers that are not Keep a Changelog sections"
+            echo "::error::Allowed: ### Added, ### Changed, ### Deprecated, ### Removed, ### Fixed, ### Security"
+            echo "Unknown headers:"
+            echo "$unknown_headers" | sed 's/^/  /'
+            exit 1
+          fi
+
+          if [ "$accepted_count" -eq 0 ]; then
             echo "::error title=Empty Changelog::No changelog content found for version $version"
             echo "::error::The release appears to have an empty changelog."
             echo ""
@@ -138,11 +155,11 @@ jobs:
             echo "Current changelog section:"
             echo "$changelog_section"
             exit 1
-          else
-            echo "Changelog validation passed: Found $subsection_count section(s)"
-            echo "Sections found:"
-            echo "$changelog_section" | grep "^### " | sed 's/^/  /'
           fi
+
+          echo "Changelog validation passed: Found $accepted_count section(s)"
+          echo "Sections found:"
+          echo "$accepted_headers" | sed 's/^/  /'
 
       - name: Add PR comment if validation fails
         if: failure()
@@ -152,14 +169,14 @@ jobs:
             const version = '${{ steps.extract_version.outputs.version }}';
             const body = `## 📝 Changelog Validation Failed
 
-            The changelog for version **${version}** appears to be empty.
+            The changelog for version **${version}** is either empty or contains H3 sections that are not part of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-            Please add content under appropriate sections like:
+            Accepted H3 sections:
             - \`### Added\` - for new features
             - \`### Changed\` - for changes in existing functionality
-            - \`### Fixed\` - for any bug fixes
-            - \`### Removed\` - for now removed features
             - \`### Deprecated\` - for soon-to-be removed features
+            - \`### Removed\` - for now removed features
+            - \`### Fixed\` - for any bug fixes
             - \`### Security\` - in case of vulnerabilities
 
             **Example:**
@@ -170,9 +187,13 @@ jobs:
 
             - Updated dependency X to version Y
             - Improved error handling in module Z
+
+            ### Security
+
+            - Bump x/crypto to 0.42.0 for CVE-2026-XXXXX
             \`\`\`
 
-            This check will pass once you add proper changelog content.`;
+            See the job log for the exact validation error.`;
 
             github.rest.issues.createComment({
               issue_number: context.issue.number,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 however this project does not use Semantic Versioning and there are no releases.
 Instead this file uses a date-based structure.
 
+## 2026-05-21
+
+### Changed
+
+- `validate-changelog.yaml` now validates the H3 sections of the version block against the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) set: `### Added`, `### Changed`, `### Deprecated`, `### Removed`, `### Fixed`, `### Security`. Unknown H3 sections fail validation. `### Security` is accepted for CVE fixes and vulnerability mitigations. Release CHANGELOGs that do not use `### Security` continue to pass.
+
 ## 2026-05-20
 
 ### Added


### PR DESCRIPTION
## Summary

`validate-changelog.yaml` now validates the H3 sections inside a release CHANGELOG against the [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/) set:

- `### Added`
- `### Changed`
- `### Deprecated`
- `### Removed`
- `### Fixed`
- `### Security`

Unknown H3 headers fail the check with a clear error pointing at the offending lines. Backwards-compatible: existing CHANGELOG.md files that do not contain `### Security` continue to pass.

## Why

Pairs with [`giantswarm/devctl` PR #1833](https://github.com/giantswarm/devctl/pull/1833), which adds a `security:` Conventional Commit type to the generated `release-please-config.json` so CVE fixes and vulnerability mitigations land in `### Security`. Without this workflow change, the new section would already pass (because the old validator counted any `### ` header), but typos and ad-hoc sections would still slip through silently.

Tightening to a closed allowlist makes the contract explicit: release CHANGELOGs are KaC, nothing else.

## Verification

Manual bash simulation of the new check against eight cases (only Added, only Security, mix of KaC sections, no sections, unknown section, no Security, trailing whitespace, lowercase typo). All behaved as expected. The change preserves the existing `if: contains(github.event.pull_request.head.ref, '#release#')` gating, so it only runs on release PRs.

## Out of scope

- Sweeping consumer CHANGELOG.md files for non-KaC sections (per-repo follow-up if any are flagged).
- Loosening Semantic Versioning expectations elsewhere in the workflow.