### PR TITLE
feat: use chore(release) prefix for release PR titles

### DIFF
--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -168,7 +168,7 @@ jobs:
           version: "${{ needs.gather_facts.outputs.version }}"
         run: |
           git add -A
-          git commit -m "release: v${{ env.version }} - version packages" -m "Release-Workflow-Run: ${{ github.run_id }}"
+          git commit -m "chore(release): v${{ env.version }} - version packages" -m "Release-Workflow-Run: ${{ github.run_id }}"
       - name: Push changes
         env:
           remote_repo: "https://${{ github.actor }}:${{ secrets.TAYLORBOT_GITHUB_ACTION }}@github.com/${{ github.repository }}.git"
@@ -270,7 +270,7 @@ jobs:
           version: "${{ needs.gather_facts.outputs.version }}"
         run: |
           git add -A
-          git commit -m "release: v${{ env.version }}" -m "Release-Workflow-Run: ${{ github.run_id }}"
+          git commit -m "chore(release): v${{ env.version }}" -m "Release-Workflow-Run: ${{ github.run_id }}"
       - name: Push changes
         env:
           remote_repo: "https://${{ github.actor }}:${{ secrets.TAYLORBOT_GITHUB_ACTION }}@github.com/${{ github.repository }}.git"
@@ -282,4 +282,4 @@ jobs:
           base: "${{ needs.gather_facts.outputs.base }}"
           version: "${{ needs.gather_facts.outputs.version }}"
         run: |
-          gh pr create --assignee ${{ github.actor }} --title "release: v${{ env.version }}" --body "" --base ${{ env.base }} --head "${{ needs.gather_facts.outputs.branch }}"
+          gh pr create --assignee ${{ github.actor }} --title "chore(release): v${{ env.version }}" --body "" --base ${{ env.base }} --head "${{ needs.gather_facts.outputs.branch }}"

--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -168,7 +168,7 @@ jobs:
           version: "${{ needs.gather_facts.outputs.version }}"
         run: |
           git add -A
-          git commit -m "Release v${{ env.version }} - version packages" -m "Release-Workflow-Run: ${{ github.run_id }}"
+          git commit -m "release: v${{ env.version }} - version packages" -m "Release-Workflow-Run: ${{ github.run_id }}"
       - name: Push changes
         env:
           remote_repo: "https://${{ github.actor }}:${{ secrets.TAYLORBOT_GITHUB_ACTION }}@github.com/${{ github.repository }}.git"
@@ -270,7 +270,7 @@ jobs:
           version: "${{ needs.gather_facts.outputs.version }}"
         run: |
           git add -A
-          git commit -m "Release v${{ env.version }}" -m "Release-Workflow-Run: ${{ github.run_id }}"
+          git commit -m "release: v${{ env.version }}" -m "Release-Workflow-Run: ${{ github.run_id }}"
       - name: Push changes
         env:
           remote_repo: "https://${{ github.actor }}:${{ secrets.TAYLORBOT_GITHUB_ACTION }}@github.com/${{ github.repository }}.git"
@@ -282,4 +282,4 @@ jobs:
           base: "${{ needs.gather_facts.outputs.base }}"
           version: "${{ needs.gather_facts.outputs.version }}"
         run: |
-          gh pr create --assignee ${{ github.actor }} --title "Release v${{ env.version }}" --body "" --base ${{ env.base }} --head "${{ needs.gather_facts.outputs.branch }}"
+          gh pr create --assignee ${{ github.actor }} --title "release: v${{ env.version }}" --body "" --base ${{ env.base }} --head "${{ needs.gather_facts.outputs.branch }}"

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -45,13 +45,17 @@ jobs:
           title=$(echo -n "${COMMIT_MESSAGE}" | head -1)
           # Matches strings like:
           #
-          #   - "Release v1.2.3"
-          #   - "Release v1.2.3-r4"
-          #   - "Release v1.2.3 (#56)"
-          #   - "Release v1.2.3-r4 (#56)"
+          #   - "release: v1.2.3"
+          #   - "release: v1.2.3-r4"
+          #   - "release: v1.2.3 (#56)"
+          #   - "release: v1.2.3-r4 (#56)"
+          #
+          # The "Release v..." form (no colon) is also accepted for
+          # backward compatibility with PRs created by older versions
+          # of the create-release-pr workflow.
           #
           # And outputs version part (1.2.3).
-          if echo "${title}" | grep -iqE '^Release v[0-9]+\.[0-9]+\.[0-9]+([.-][^ .-][^ ]*)?( \(#[0-9]+\))?$' ; then
+          if echo "${title}" | grep -iqE '^Release:? v[0-9]+\.[0-9]+\.[0-9]+([.-][^ .-][^ ]*)?( \(#[0-9]+\))?$' ; then
           version=$(echo "${title}" | cut -d ' ' -f 2)
           fi
           version="${version#v}" # Strip "v" prefix.
@@ -76,7 +80,7 @@ jobs:
           COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
           title=$(echo -n "${COMMIT_MESSAGE}" | head -1)
-          if echo "${title}" | grep -qE '^release v[0-9]+\.[0-9]+\.[0-9]+([.-][^ .-][^ ]*)?( \(#[0-9]+\))?$' ; then
+          if echo "${title}" | grep -iqE '^release:? v[0-9]+\.[0-9]+\.[0-9]+([.-][^ .-][^ ]*)?( \(#[0-9]+\))?$' ; then
             version=$(echo "${title}" | cut -d ' ' -f 2)
           fi
           version=$(echo "${title}" | cut -d ' ' -f 2)

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -45,17 +45,17 @@ jobs:
           title=$(echo -n "${COMMIT_MESSAGE}" | head -1)
           # Matches strings like:
           #
-          #   - "release: v1.2.3"
-          #   - "release: v1.2.3-r4"
-          #   - "release: v1.2.3 (#56)"
-          #   - "release: v1.2.3-r4 (#56)"
+          #   - "chore(release): v1.2.3"
+          #   - "chore(release): v1.2.3-r4"
+          #   - "chore(release): v1.2.3 (#56)"
+          #   - "chore(release): v1.2.3-r4 (#56)"
           #
-          # The "Release v..." form (no colon) is also accepted for
+          # The legacy "Release v..." form is also accepted for
           # backward compatibility with PRs created by older versions
           # of the create-release-pr workflow.
           #
           # And outputs version part (1.2.3).
-          if echo "${title}" | grep -iqE '^Release:? v[0-9]+\.[0-9]+\.[0-9]+([.-][^ .-][^ ]*)?( \(#[0-9]+\))?$' ; then
+          if echo "${title}" | grep -iqE '^(chore\(release\):|Release) v[0-9]+\.[0-9]+\.[0-9]+([.-][^ .-][^ ]*)?( \(#[0-9]+\))?$' ; then
           version=$(echo "${title}" | cut -d ' ' -f 2)
           fi
           version="${version#v}" # Strip "v" prefix.
@@ -80,7 +80,7 @@ jobs:
           COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
           title=$(echo -n "${COMMIT_MESSAGE}" | head -1)
-          if echo "${title}" | grep -iqE '^release:? v[0-9]+\.[0-9]+\.[0-9]+([.-][^ .-][^ ]*)?( \(#[0-9]+\))?$' ; then
+          if echo "${title}" | grep -iqE '^(chore\(release\):|Release) v[0-9]+\.[0-9]+\.[0-9]+([.-][^ .-][^ ]*)?( \(#[0-9]+\))?$' ; then
             version=$(echo "${title}" | cut -d ' ' -f 2)
           fi
           version=$(echo "${title}" | cut -d ' ' -f 2)

--- a/.github/workflows/update-action-version.yaml
+++ b/.github/workflows/update-action-version.yaml
@@ -1,8 +1,9 @@
 # This reusable workflow runs when a release PR is created and updates the
 # version in a composite action's action.yml to match the release version.
 #
-# It finds the open release PR (matching "Release v<semver>"), extracts the
-# version, and updates the specified action.yml file on the release branch.
+# It finds the open release PR (matching "release: v<semver>" or the legacy
+# "Release v<semver>"), extracts the version, and updates the specified
+# action.yml file on the release branch.
 
 name: Update action version
 
@@ -39,8 +40,9 @@ jobs:
           # List open PRs
           prs=$(gh pr list --repo "${{ github.repository }}" --state open --json title,number,headRefName)
 
-          # Filter for release PRs matching "Release v<semver>"
-          release_prs=$(echo "$prs" | jq '[.[] | select(.title | test("^Release v[0-9]+\\.[0-9]+\\.[0-9]+"))]')
+          # Filter for release PRs matching "release: v<semver>" (current
+          # format) or "Release v<semver>" (legacy format).
+          release_prs=$(echo "$prs" | jq '[.[] | select(.title | test("^[Rr]elease:? v[0-9]+\\.[0-9]+\\.[0-9]+"))]')
 
           count=$(echo "$release_prs" | jq 'length')
           if [ "$count" -ne 1 ]; then
@@ -50,7 +52,7 @@ jobs:
 
           title=$(echo "$release_prs" | jq -r '.[0].title')
           branch=$(echo "$release_prs" | jq -r '.[0].headRefName')
-          version=$(echo "$title" | sed 's/^Release v//')
+          version=$(echo "$title" | sed -E 's/^[Rr]elease:? v//')
 
           echo "Found release PR: $title"
           echo "Version: $version"

--- a/.github/workflows/update-action-version.yaml
+++ b/.github/workflows/update-action-version.yaml
@@ -1,9 +1,9 @@
 # This reusable workflow runs when a release PR is created and updates the
 # version in a composite action's action.yml to match the release version.
 #
-# It finds the open release PR (matching "release: v<semver>" or the legacy
-# "Release v<semver>"), extracts the version, and updates the specified
-# action.yml file on the release branch.
+# It finds the open release PR (matching "chore(release): v<semver>" or the
+# legacy "Release v<semver>"), extracts the version, and updates the
+# specified action.yml file on the release branch.
 
 name: Update action version
 
@@ -40,9 +40,9 @@ jobs:
           # List open PRs
           prs=$(gh pr list --repo "${{ github.repository }}" --state open --json title,number,headRefName)
 
-          # Filter for release PRs matching "release: v<semver>" (current
-          # format) or "Release v<semver>" (legacy format).
-          release_prs=$(echo "$prs" | jq '[.[] | select(.title | test("^[Rr]elease:? v[0-9]+\\.[0-9]+\\.[0-9]+"))]')
+          # Filter for release PRs matching "chore(release): v<semver>"
+          # (current format) or "Release v<semver>" (legacy format).
+          release_prs=$(echo "$prs" | jq '[.[] | select(.title | test("^(chore\\(release\\):|Release) v[0-9]+\\.[0-9]+\\.[0-9]+"; "i"))]')
 
           count=$(echo "$release_prs" | jq 'length')
           if [ "$count" -ne 1 ]; then
@@ -52,7 +52,7 @@ jobs:
 
           title=$(echo "$release_prs" | jq -r '.[0].title')
           branch=$(echo "$release_prs" | jq -r '.[0].headRefName')
-          version=$(echo "$title" | sed -E 's/^[Rr]elease:? v//')
+          version=$(echo "$title" | sed -E 's/^(chore\(release\):|Release) v//')
 
           echo "Found release PR: $title"
           echo "Version: $version"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ Instead this file uses a date-based structure.
 
 ### Changed
 
-- `create-release-pr` now opens release PRs with a Conventional Commits-compatible title of the form `release: vX.Y.Z` (previously `Release vX.Y.Z`). The release commit message it creates uses the same form.
-- `create-release` and `update-action-version` accept both the new `release: vX.Y.Z` form and the legacy `Release vX.Y.Z` form, so in-flight release PRs created by older versions of `create-release-pr` continue to be picked up after their merge commit lands.
+- `create-release-pr` now opens release PRs with a Conventional Commits-compatible title of the form `chore(release): vX.Y.Z` (previously `Release vX.Y.Z`). The release commit message it creates uses the same form.
+- `create-release` and `update-action-version` accept both the new `chore(release): vX.Y.Z` form and the legacy `Release vX.Y.Z` form, so in-flight release PRs created by older versions of `create-release-pr` continue to be picked up after their merge commit lands.
 
 ## 2026-05-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 however this project does not use Semantic Versioning and there are no releases.
 Instead this file uses a date-based structure.
 
+## 2026-05-21
+
+### Changed
+
+- `create-release-pr` now opens release PRs with a Conventional Commits-compatible title of the form `release: vX.Y.Z` (previously `Release vX.Y.Z`). The release commit message it creates uses the same form.
+- `create-release` and `update-action-version` accept both the new `release: vX.Y.Z` form and the legacy `Release vX.Y.Z` form, so in-flight release PRs created by older versions of `create-release-pr` continue to be picked up after their merge commit lands.
+
 ## 2026-05-20
 
 ### Added


### PR DESCRIPTION
## Summary

- Change the release PR title produced by `create-release-pr` from `Release vX.Y.Z` to `chore(release): vX.Y.Z` so the title (and its squash-merge commit) is a valid Conventional Commit (`chore` type, `release` scope).
- Update the matching release commit messages in `create-release-pr` to the same form.
- Extend the title parsers in `create-release` and `update-action-version` to accept both the new `chore(release): vX.Y.Z` form and the legacy `Release vX.Y.Z` form, so consumer repos with an in-flight release PR created by an older version of `create-release-pr` keep working after they bump to this version.

## Checklist

- I have updated the [CHANGELOG.md](../CHANGELOG.md) with a description of the change

## Test plan

- [ ] Trigger `create-release-pr` in a sandbox consumer repo and verify the opened PR title is `chore(release): vX.Y.Z`
- [ ] Merge that PR and verify `create-release` picks up the squash commit (`chore(release): vX.Y.Z (#N)`) and tags + publishes the release
- [ ] In a consumer that calls `update-action-version`, verify the workflow finds the new-format release PR and writes the version into `action.yml`
- [ ] Re-run `create-release` against a historical merge commit that still uses `Release vX.Y.Z` to confirm legacy parsing still works