### PR TITLE
fix: use conventional commit prefix on bump-version PR title and commit

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -141,7 +141,7 @@ jobs:
         run: |
           file="${{ needs.gather_facts.outputs.project_go_path }}"
           git add $file
-          git commit -m "Bump version to ${{ steps.update_project_go.outputs.new_version }}"
+          git commit -m "chore: bump version to ${{ steps.update_project_go.outputs.new_version }}"
       - name: Push changes
         env:
           REMOTE_REPO: "https://${{ github.actor }}:${{ secrets.TAYLORBOT_GITHUB_ACTION }}@github.com/${{ github.repository }}.git"
@@ -154,7 +154,7 @@ jobs:
           base: "${{ github.ref }}"
           branch: "${{ github.ref }}-version-bump"
           version: "${{ needs.gather_facts.outputs.version }}"
-          title: "Bump version to ${{ steps.update_project_go.outputs.new_version }}"
+          title: "chore: bump version to ${{ steps.update_project_go.outputs.new_version }}"
         run: |
           gh pr create --title "${{ env.title }}" --body "" \
             --base ${{ env.base }} --head ${{ env.branch }} --reviewer ${{ github.actor }}
@@ -164,7 +164,7 @@ jobs:
           base: "${{ github.ref }}"
           branch: "${{ github.ref }}-version-bump"
           version: "${{ needs.gather_facts.outputs.version }}"
-          title: "Bump version to ${{ steps.update_project_go.outputs.new_version }}"
+          title: "chore: bump version to ${{ steps.update_project_go.outputs.new_version }}"
         run: |
           gh pr merge --auto --squash "${{ env.branch }}" \
             || echo "::warning::Auto-merge not allowed. Please adjust the repository settings."


### PR DESCRIPTION
The post-release dev-bump PR title and commit message lacked a conventional commit prefix, causing semantic_pull_request checks to fail. Changed from 'Bump version to X.Y.Z-dev' to 'chore: bump 
  version to X.Y.Z-dev'.