### PR TITLE
fix: use conventional commit prefixes on fix-vulnerabilities and update-chart PRs

### DIFF
--- a/.github/workflows/fix-vulnerabilities.yaml
+++ b/.github/workflows/fix-vulnerabilities.yaml
@@ -113,7 +113,7 @@ jobs:
             echo "No changes found"
             skip=true
           else
-            git commit -m "Remediate Nancy findings"
+            git commit -m "fix(nancy): remediate nancy findings"
             skip=false
           fi
           echo "skip=${skip}" >> $GITHUB_OUTPUT
@@ -131,7 +131,7 @@ jobs:
         if: "${{ steps.commit_changes.outputs.skip != 'true' }}"
         run: |
           gh pr create \
-            --title "Remediate Nancy findings on ${{ needs.gather_facts.outputs.branch }}" \
+            --title "fix(nancy): remediate findings on ${{ needs.gather_facts.outputs.branch }}" \
             --body "Fix Nancy findings on branch ${{ needs.gather_facts.outputs.branch }}" \
             --head "${{ steps.create_branch.outputs.branch }}" \
             --base "${{ needs.gather_facts.outputs.branch }}"

--- a/.github/workflows/update-chart.yaml
+++ b/.github/workflows/update-chart.yaml
@@ -117,7 +117,7 @@ jobs:
       - name: Create update commit
         run: |
           git add -A
-          git commit -m "Automated update from upstream"
+          git commit -m "chore(chart): automated update from upstream"
       - name: Push changes
         env:
           remote_repo: "https://${{ github.actor }}:${{ secrets.TAYLORBOT_GITHUB_ACTION }}@github.com/${{ github.repository }}.git"
@@ -130,7 +130,7 @@ jobs:
           head: "${{ needs.gather_facts.outputs.branch }}"
         run: |
           gh pr create \
-            --title "Automated update from upstream" \
+            --title "chore(chart): automated update from upstream" \
             --label "automated-update" \
             --base "${{ env.base }}" \
             --head "${{ env.head }}" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Instead this file uses a date-based structure.
 - `create-release-pr` now opens release PRs with a Conventional Commits-compatible title of the form `chore(release): vX.Y.Z` (previously `Release vX.Y.Z`). The release commit message it creates uses the same form.
 - `create-release` and `update-action-version` accept both the new `chore(release): vX.Y.Z` form and the legacy `Release vX.Y.Z` form, so in-flight release PRs created by older versions of `create-release-pr` continue to be picked up after their merge commit lands.
 - `validate-changelog.yaml` now validates the H3 sections of the version block against the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) set: `### Added`, `### Changed`, `### Deprecated`, `### Removed`, `### Fixed`, `### Security`. Unknown H3 sections fail validation. `### Security` is accepted for CVE fixes and vulnerability mitigations. Release CHANGELOGs that do not use `### Security` continue to pass.
+- `fix-vulnerabilities` now opens PRs with the Conventional Commits title `fix(nancy): remediate findings on <branch>` (previously `Remediate Nancy findings on <branch>`). The intermediate commit it creates uses `fix(nancy): remediate nancy findings`.
+- `update-chart` now opens PRs with the Conventional Commits title `chore(chart): automated update from upstream` (previously `Automated update from upstream`). The intermediate commit it creates uses the same form.
 
 ## 2026-05-20
 


### PR DESCRIPTION
## Summary

Update the PR titles (and intermediate commits) produced by the `fix-vulnerabilities` and `update-chart` reusable workflows so that, when squash-merged into a Conventional Commits-validated main branch, the squash commit title is a valid Conventional Commits message.

- `fix-vulnerabilities`: `Remediate Nancy findings on <branch>` → `fix(nancy): remediate findings on <branch>`
- `update-chart`: `Automated update from upstream` → `chore(chart): automated update from upstream`

Release automation PRs are out of scope here — those were already converted in #178 and #179.

Refs: https://github.com/giantswarm/giantswarm/issues/36660