### PR TITLE
feat(release): auto-approve release PRs via dedicated GitHub App

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,6 +20,12 @@ on:
       RELEASE_PLEASE_PRIVATE_KEY:
         description: Private key for create-github-app-token
         required: true
+      RELEASE_PLEASE_APPROVER_CLIENT_ID:
+        description: Client ID for the release-please-approver App used to satisfy required-approval branch protection on release PRs. Optional — when omitted, the auto-approve step is skipped and the release PR will need a human approval to merge.
+        required: false
+      RELEASE_PLEASE_APPROVER_PRIVATE_KEY:
+        description: Private key for the release-please-approver App. Required if RELEASE_PLEASE_APPROVER_CLIENT_ID is set.
+        required: false
     outputs:
       release_created:
         description: "Set to 'true' if a release was created."
@@ -71,6 +77,38 @@ jobs:
           token: ${{ steps.generate_token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      # Auto-approve release-please PRs via a dedicated GitHub App so branch
+      # protection's required-approval rule is satisfied and `--auto` can complete
+      # the merge once checks pass. The approving identity is intentionally distinct
+      # from the release-please App that authors the PR (GitHub rejects self-approval).
+      # release-please PRs aggregate commits that were already reviewed on their way
+      # to the base branch; this approval covers only the auto-generated CHANGELOG
+      # aggregation, not the underlying changes.
+      #
+      # The approver secrets are optional — when omitted, this whole pair of steps
+      # is skipped and the PR will need a human approval (existing-caller behavior).
+      - name: Generate release-please-approver App token
+        id: approver_token
+        if: ${{ steps.release_please.outputs.pr != '' && inputs.auto-merge-level != 'none' && env.APPROVER_CLIENT_ID != '' }}
+        env:
+          APPROVER_CLIENT_ID: ${{ secrets.RELEASE_PLEASE_APPROVER_CLIENT_ID }}
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.RELEASE_PLEASE_APPROVER_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_APPROVER_PRIVATE_KEY }}
+
+      - name: Auto-approve Release Please PR
+        if: ${{ steps.approver_token.outputs.token != '' }}
+        env:
+          GH_TOKEN: ${{ steps.approver_token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+          PR_JSON: ${{ steps.release_please.outputs.pr }}
+        run: |
+          set -euo pipefail
+          pr_number=$(jq -r '.number' <<<"$PR_JSON")
+          gh pr review "$pr_number" --approve \
+            --body "Auto-approved by release-please-approver. Underlying commits were reviewed on their feature PRs; this satisfies branch protection's required-approval rule for the aggregated release PR."
 
       # Reconcile auto-merge on the open Release Please PR every run. release-please
       # keeps a single PR open and rewrites it as commits land, so its bump level can

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ on:
         description: Private key for create-github-app-token
         required: true
       RELEASE_PLEASE_APPROVER_CLIENT_ID:
-        description: Client ID for the release-please-approver App used to satisfy required-approval branch protection on release PRs. Optional — when omitted, the auto-approve step is skipped and the release PR will need a human approval to merge.
+        description: Client ID for the release-please-approver App. Optional — when omitted, auto-approve is skipped and the release PR needs a human approval to merge.
         required: false
       RELEASE_PLEASE_APPROVER_PRIVATE_KEY:
         description: Private key for the release-please-approver App. Required if RELEASE_PLEASE_APPROVER_CLIENT_ID is set.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -105,9 +105,12 @@ jobs:
           base_branch=$(jq -r '.baseBranchName' <<<"$PR_JSON")
 
           # Read the single root (".") entry of the release-please manifest at a ref.
+          # On a fresh repo the manifest is an empty object until the first release lands,
+          # so a missing "." key is normalized to 0.0.0 — otherwise the numeric comparisons
+          # below silently fall through and the first release's bump is classified as none.
           manifest_version() {
             gh api "repos/${GH_REPO}/contents/.release-please-manifest.json?ref=$1" \
-              -H "Accept: application/vnd.github.raw" | jq -r '.["."]'
+              -H "Accept: application/vnd.github.raw" | jq -r '.["."] // "0.0.0"'
           }
 
           current=$(manifest_version "$base_branch")

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -107,8 +107,7 @@ jobs:
         run: |
           set -euo pipefail
           pr_number=$(jq -r '.number' <<<"$PR_JSON")
-          gh pr review "$pr_number" --approve \
-            --body "Auto-approved by release-please-approver. Underlying commits were reviewed on their feature PRs; this satisfies branch protection's required-approval rule for the aggregated release PR."
+          gh pr review "$pr_number" --approve
 
       # Reconcile auto-merge on the open Release Please PR every run. release-please
       # keeps a single PR open and rewrites it as commits land, so its bump level can


### PR DESCRIPTION
> **Stacked on #191** — base is `fix-first-release-auto-merge-detection`. The diff here shows only the new auto-approve mechanism; #191 must merge first (or the base of this PR retargeted to `main`).

## Summary

`gh pr merge --auto` never completes on release-please PRs in repos with required-approval branch protection, because nothing satisfies the approval requirement:

- The PR author is the `release-please-workflow` App, which cannot self-approve.
- No human is meaningfully reviewing the auto-generated CHANGELOG diff.
- `bypass_pull_request_allowances` on classic branch protection **does not** allow merging un-approved PRs via the API — empirically verified by attempting `gh pr merge --squash` authenticated as the bypass App and getting `the base branch policy prohibits the merge`. The bypass only covers direct branch pushes.

This PR adds an optional auto-approve step that uses a dedicated `release-please-approver` GitHub App to submit an approving review. The App is intentionally distinct from the release-please App that authors the PR (so the review counts). With approval in place, the existing `--auto --squash` step merges as soon as required checks pass.

## Scope

- **Only** approves PRs whose number comes from `steps.release_please.outputs.pr` — there is no path for this step to touch non-release-please PRs.
- **Optional secrets.** `RELEASE_PLEASE_APPROVER_CLIENT_ID` / `RELEASE_PLEASE_APPROVER_PRIVATE_KEY` are `required: false`. Callers that don't provide them see no behavior change.
- The approval is submitted without a review body — the rationale lives in the YAML comment above the step, not in noise on every release PR.

## Caller-side requirements

Repos that want to opt in need to:
1. Install the `release-please-approver` App.
2. Provide the two new secrets (org-level secret is the recommended pattern, mirroring the existing `RELEASE_PLEASE_CLIENT_ID` / `RELEASE_PLEASE_PRIVATE_KEY`).
3. Add the two new entries to the `secrets:` block of their generated `release-please.yaml` workflow file. **devctl template update required** for org-wide rollout — out of scope for this PR.

### App permissions — important

The approver App needs **`Contents: Read and write`** in addition to `Pull requests: Read and write`. \`Contents: Read\` alone is *not* enough — GitHub will silently submit the review but not count it toward branch protection's required-approval rule (\`authorAssociation\` reports \`NONE\` and \`reviewDecision\` stays \`REVIEW_REQUIRED\`). This is poorly documented; the symptom is "the approval is recorded but the PR still says review required." Empirically verified end-to-end on \`giantswarm/test-release-please\`.

## Verified end-to-end

Tested on \`giantswarm/test-release-please\` against the live branch protection (1 required approval). With the approver App's review counting, \`gh pr merge --auto --squash\` completed the merge and cut \`v1.0.0\` ~30 seconds after the workflow run started.

## Test plan

- [x] Empirically verified the App-review-counting mechanism (probe workflow on test-release-please).
- [x] End-to-end run: release-please PR auto-approved → auto-merged → v1.0.0 tag + release created.
- [ ] Land #191 (this PR's stacked base).
- [ ] Retarget this PR's base to \`main\` (auto-handled by GitHub on #191 merge).