### PR TITLE
fix: install gitsemver in create-release build artifacts job

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -337,6 +337,14 @@ jobs:
         with:
           binary: "architect"
           version: "6.14.1"
+      - name: Install gitsemver
+        uses: giantswarm/install-binary-action@5bef88f65012037dd836117c8d344b21bb559854 # v4.1.0
+        with:
+          binary: "gitsemver"
+          version: "1.1.2"
+          download_url: "https://github.com/giantswarm/${binary}/releases/download/v${version}/${binary}-v${version}-linux-amd64.tar.gz"
+          tarball_binary_path: "*/${binary}"
+          smoke_test: "${binary} version"
       - name: Set up Go ${{ env.GO_VERSION }}
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
@@ -353,7 +361,7 @@ jobs:
         run: make package-${{ matrix.platform }}
       - name: Specify package file name based on platform
         run: |
-          if [[ "${{ matrix.platform }}" == "windows-amd64" ]]; then
+          if [[  "${{ matrix.platform }}" == "windows-amd64" ]]; then
             echo "FILE_NAME=${{ github.event.repository.name }}-${{ env.TAG }}-${{ matrix.platform }}.zip" >> $GITHUB_ENV
           else
             echo "FILE_NAME=${{ github.event.repository.name }}-${{ env.TAG }}-${{ matrix.platform }}.tar.gz" >> $GITHUB_ENV


### PR DESCRIPTION
## Summary

- Adds a `gitsemver` install step to the `create_and_upload_build_artifacts` job in `create-release.yaml`

## Background

`Makefile.gen.go.mk` (generated by devctl) was updated to compute the build version with:

```makefile
VERSION := $(shell gitsemver version)
```

This was introduced as part of the architect-orb v9.0.0 migration where `gitsemver` replaced `architect project version` as the canonical version-stamping tool. In CircleCI, `gitsemver` is bundled inside the architect executor image. On GHA runners it is not present.

**Without this fix**, `gitsemver` is missing on the runner → `VERSION` evaluates to empty → the binary is built as e.g. `devctl-v-linux-amd64` → the upload step looks for `devctl-v8.0.0-linux-amd64.tar.gz` → `stat: no such file or directory` → job fails.

Observed failing run: https://github.com/giantswarm/devctl/actions/runs/26753246655/job/78846384928

## Test plan

- [ ] Re-run a release workflow in a repo that uses `build-release-artifacts: true` and verify all platform packages are built and uploaded successfully