### PR TITLE
Bump gitsemver to v2.0.0 in create-release workflow

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -349,7 +349,7 @@ jobs:
         uses: giantswarm/install-binary-action@5bef88f65012037dd836117c8d344b21bb559854 # v4.1.0
         with:
           binary: "gitsemver"
-          version: "1.1.2"
+          version: "2.0.0"
           download_url: "https://github.com/giantswarm/${binary}/releases/download/v${version}/${binary}-v${version}-linux-amd64.tar.gz"
           tarball_binary_path: "*/${binary}"
           smoke_test: "${binary} --version"


### PR DESCRIPTION
## What

Bump the pinned `gitsemver` version from `1.1.2` to `2.0.0` in the build-artifacts job of `create-release.yaml`.

## Why

`gitsemver` v2.0.0 (released 2026-06-02) renamed the `version` subcommand to `get`. `devctl` v8.3.1 updated its `gen makefile` output to call `gitsemver get`, and devctl's own Makefile was regenerated with that change.

With `gitsemver` 1.1.2 still pinned here, the build step exits with:

```
error: unknown command "get" for "gitsemver"
```

`VERSION` is left empty, the tarball is named `devctl-v-<platform>.tar.gz` instead of `devctl-v<X.Y.Z>-<platform>.tar.gz`, and `gh release upload` fails with `no such file or directory`.

Any repo that has already regenerated its Makefile with devctl ≥ v8.3.1 will hit the same failure until this is merged.