### PR TITLE
fix(sync-from-upstream): set git safe.directory for values-sync drift detection

### DIFF
--- a/.github/workflows/sync-from-upstream.yaml
+++ b/.github/workflows/sync-from-upstream.yaml
@@ -106,6 +106,9 @@ jobs:
           fi
           drift=$(docker run --rm \
             -v ${{ github.workspace }}:/github/workspace \
+            -e GIT_CONFIG_COUNT=1 \
+            -e GIT_CONFIG_KEY_0=safe.directory \
+            -e GIT_CONFIG_VALUE_0=/github/workspace \
             gsoci.azurecr.io/giantswarm/shield-values-sync:0.0.5 \
             --show-git-diff \
             --chart-dir /github/workspace/${{ steps.chart.outputs.chart_dir }} \


### PR DESCRIPTION
## Problem

The `Detect upstream values drift` step in `sync-from-upstream.yaml` fails with:

\`\`\`
Error: computing diff for falco: finding git root for /github/workspace/helm/falco/charts/falco/values.yaml: exit status 128
\`\`\`

`shield-values-sync --show-git-diff` shells out to git to diff upstream values against `main`. The step mounts the workspace into a container running as **root (uid 0)**, while `actions/checkout` writes the repo as the **runner user (uid 1001)**. Git ≥2.35.2 then refuses every command on the repo with *"detected dubious ownership"* → `git rev-parse --show-toplevel` exits 128, surfacing as the "finding git root" error.

Because the step is guarded with `|| true`, the job stays green but the drift report is silently lost — so the "Values from upstream chart have drifted" warning never gets posted on update PRs.

## Fix

Inject `safe.directory=/github/workspace` into git via `GIT_CONFIG_*` env vars on the one `docker run` that uses `--show-git-diff`. This is process-scoped (no image rebuild) and only touches the git-using step — `Run values-sync` and `schema-gen` don't shell out to git.

## Notes

A more durable follow-up would be to bake `safe.directory=*` into the `shield-values-sync` image so any future git-using flag is covered without each workflow needing these env vars.