### PR TITLE
Bump Go to 1.26.3 in create-release build artifacts job

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -333,7 +333,8 @@ jobs:
           - windows-amd64
     env:
       GITHUB_TOKEN: "${{ secrets.TAYLORBOT_GITHUB_ACTION }}"
-      GO_VERSION: 1.21.3
+      # renovate: datasource=golang-version depName=go
+      GO_VERSION: 1.26.3
       ARTIFACT_DIR: bin-dist
       TAG: v${{ needs.gather_facts.outputs.version }}
     needs:


### PR DESCRIPTION
## What

Bump `GO_VERSION` from `1.21.3` to `1.26.3` in the build-artifacts job of `create-release.yaml`. Also adds a Renovate comment so future bumps are automatic.

## Why

Any repo with `go 1.22+` in `go.mod` fails the build step with:

```
go: go.mod requires go >= X.Y.Z (running go 1.21.3; GOTOOLCHAIN=local)
```

`devctl` currently requires `go 1.26.0` / `toolchain go1.26.3`, which is what surfaced this.