### PR TITLE
Download architect binary instead of tarball when installing it

### DIFF
--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -196,7 +196,7 @@ jobs:
           binary: architect
           # renovate: datasource=github-tags depName=giantswarm/architect
           version: v8.2.1
-          download_url: "https://github.com/giantswarm/architect/releases/download/${version}/architect-${version}-linux-amd64.tar.gz"
+          download_url: "https://github.com/giantswarm/architect/releases/download/${version}/architect-${version}-linux-amd64"
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 however this project does not use Semantic Versioning and there are no releases.
 Instead this file uses a date-based structure.
 
+## 2026-06-18
+
+### Fixed
+
+- Download `architect` binary instead of tarball when installing it.
+
 ## 2026-06-08
 
 ### Fixed


### PR DESCRIPTION
Towards https://gigantic.slack.com/archives/C02GDJJ68Q1/p1781774156485399

Now cli flavoured repositories do not upload tarballs to their Github releases assets, just the binaries.