### PR TITLE
Add vulnerability-check reusable workflow

### DIFF
--- a/.github/workflows/vulnerability-check.yaml
+++ b/.github/workflows/vulnerability-check.yaml
@@ -1,0 +1,65 @@
+name: Vulnerability check
+
+on:
+  workflow_call:
+    secrets:
+      NANCY_USER:
+        description: User to authenticate against the OSS Index database.
+        required: true
+      NANCY_TOKEN:
+        description: Token to authenticate against the OSS Index database.
+        required: true
+      OSSI_OSSINDEXURL:
+        description: Custom OSS Index / Sonatype endpoint URL. Defaults to the public OSS Index when unset.
+        required: false
+
+permissions: {}
+
+jobs:
+  nancy:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+
+      - name: Install nancy
+        env:
+          NANCY_VERSION: v2.1.0
+        run: |
+          curl -sSL -o /usr/local/bin/nancy \
+            "https://github.com/sonatype-nexus-community/nancy/releases/download/${NANCY_VERSION}/nancy-${NANCY_VERSION}-linux-amd64"
+          chmod +x /usr/local/bin/nancy
+
+      - name: Check for vulnerable dependencies
+        env:
+          CGO_ENABLED: "0"
+          OSSI_USERNAME: ${{ secrets.NANCY_USER }}
+          OSSI_TOKEN: ${{ secrets.NANCY_TOKEN }}
+          OSSI_OSSINDEXURL: ${{ secrets.OSSI_OSSINDEXURL }}
+        run: |
+          set +e
+          go list -json -m all \
+            | nancy sleuth --skip-update-check \
+              --quiet --exclude-vulnerability-file ./.nancy-ignore \
+              --additional-exclude-vulnerability-files ./.nancy-ignore.generated 2>&1 \
+              | tee ./nancy-results.txt ; nancy_result=${PIPESTATUS[1]}
+          grep -qF \
+              -e 'error accessing OSS Index' \
+              -e 'Error: guide API request failed' \
+              nancy-results.txt; grep_result=$?
+          set -e
+          # A scanner outage must not block the merge queue: skip only when nancy failed AND the output shows an upstream error.
+          if [[ $nancy_result -ne 0 && $grep_result -eq 0 ]]; then
+            echo "Ignoring failed scan due to a problem with the external scanner."
+            exit 0
+          fi
+          exit $nancy_result

--- a/.github/workflows/vulnerability-check.yaml
+++ b/.github/workflows/vulnerability-check.yaml
@@ -10,8 +10,8 @@ on:
         description: Token to authenticate against the OSS Index database.
         required: true
       OSSI_OSSINDEXURL:
-        description: Custom OSS Index / Sonatype endpoint URL. Defaults to the public OSS Index when unset.
-        required: false
+        description: OSS Index / Sonatype endpoint URL. Must match the endpoint used by the CircleCI scan.
+        required: true
 
 permissions: {}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Instead this file uses a date-based structure.
 
 ### Added
 
-- `vulnerability-check.yaml` reusable workflow: runs `nancy sleuth` against the Go module graph (`go list -json -m all`) to flag dependencies with known vulnerabilities, honouring `.nancy-ignore` and `.nancy-ignore.generated`. Call it on `pull_request` and `merge_group` to gate the merge queue. Authenticates to OSS Index via the `NANCY_USER`/`NANCY_TOKEN` secrets and accepts an optional `OSSI_OSSINDEXURL` for a custom endpoint. A scanner outage exits `0` so it does not block merges.
+- `vulnerability-check.yaml` reusable workflow: runs `nancy sleuth` against the Go module graph (`go list -json -m all`) to flag dependencies with known vulnerabilities, honouring `.nancy-ignore` and `.nancy-ignore.generated`. Call it on `pull_request` and `merge_group` to gate the merge queue. Authenticates to OSS Index via the `NANCY_USER`/`NANCY_TOKEN` and `OSSI_OSSINDEXURL` secrets. A scanner outage exits `0` so it does not block merges.
 
 ## 2026-06-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 however this project does not use Semantic Versioning and there are no releases.
 Instead this file uses a date-based structure.
 
+## 2026-06-20
+
+### Added
+
+- `vulnerability-check.yaml` reusable workflow: runs `nancy sleuth` against the Go module graph (`go list -json -m all`) to flag dependencies with known vulnerabilities, honouring `.nancy-ignore` and `.nancy-ignore.generated`. Call it on `pull_request` and `merge_group` to gate the merge queue. Authenticates to OSS Index via the `NANCY_USER`/`NANCY_TOKEN` secrets and accepts an optional `OSSI_OSSINDEXURL` for a custom endpoint. A scanner outage exits `0` so it does not block merges.
+
 ## 2026-06-18
 
 ### Fixed


### PR DESCRIPTION
## What

Adds a `vulnerability-check.yaml` reusable workflow that runs `nancy sleuth` against the Go module graph (`go list -json -m all`), honouring `.nancy-ignore` and `.nancy-ignore.generated`.

## Why

Nancy currently runs in CircleCI (architect-orb `go-test`) on **every** build (push, rebase, draft, Renovate bump). Because the scan is authenticated against OSS Index, that volume drove the Sonatype credit overrun that broke CI on `main`. Calling this workflow on `pull_request` + `merge_group` lets the blocking scan run **once per merge** via the merge queue, scanning the exact commit that lands while cutting the redundant per-build scans.

This is the first, additive piece (no caller yet, so no behaviour change for any repo). The pilot caller (`giantswarm/microerror`), the architect-orb opt-out, and the merge-queue ruleset follow.

## Prerequisite

`OSSI_OSSINDEXURL` must be added as a GitHub Actions **org secret** (same value as the CircleCI env var) before any caller runs. The scan requires it so it hits the same OSS Index/Sonatype endpoint as the CircleCI scan; `NANCY_USER`/`NANCY_TOKEN` already exist as org secrets.

## Notes

- Auth mirrors the existing `fix-vulnerabilities.yaml` pattern: `NANCY_USER`/`NANCY_TOKEN` → `OSSI_USERNAME`/`OSSI_TOKEN`, plus `OSSI_OSSINDEXURL` for the endpoint.
- Ports the scanner-outage guard from the orb (exit 0 when nancy fails *and* the output shows an upstream error) so a Sonatype outage cannot wedge the merge queue.
- Actions are SHA-pinned; `checkout` uses `persist-credentials: false`; least-privilege `contents: read`.