### PR TITLE
fix: remove GitHub Actions script injection in debug_info step (CWE-94)

### DIFF
--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -20,10 +20,9 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Print github context JSON
-        run: |
-          cat <<EOF
-          ${{ toJson(github) }}
-          EOF
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"
   gather_facts:
     name: Gather facts
     runs-on: ubuntu-24.04

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -23,10 +23,9 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Print github context JSON
-        run: |
-          cat <<EOF
-          ${{ toJson(github) }}
-          EOF
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"
   gather_facts:
     name: Gather facts
     runs-on: ubuntu-24.04

--- a/.github/workflows/ensure-major-version-tags.yaml
+++ b/.github/workflows/ensure-major-version-tags.yaml
@@ -11,10 +11,9 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Print github context JSON
-        run: |
-          cat <<EOF
-          ${{ toJson(github) }}
-          EOF
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"
   ensure_major_version_tags:
     name: Ensure major version tags
     runs-on: ubuntu-24.04

--- a/.github/workflows/update-chart.yaml
+++ b/.github/workflows/update-chart.yaml
@@ -22,10 +22,9 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Print github context JSON
-        run: |
-          cat <<EOF
-          ${{ toJson(github) }}
-          EOF
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"
   gather_facts:
     name: Gather facts
     runs-on: ubuntu-24.04

--- a/.github/workflows/validate-workflows.yaml
+++ b/.github/workflows/validate-workflows.yaml
@@ -54,3 +54,26 @@ jobs:
         with:
           show-ascii-art: false
           path-to-workflows: '.github/workflows/*.yaml'
+
+  analyze-actions:
+    name: Analyze workflows with zizmor (report-only)
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      security-events: write # upload SARIF to the Security tab (code scanning is enabled)
+      actions: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      # Report-only: zizmor uploads findings to the Security tab for visibility but never
+      # blocks PRs. The repo carries pre-existing findings that are tracked separately; this
+      # scan is here to surface regressions (e.g. re-introducing `${{ toJson(github) }}` in a
+      # `run:` block) that CodeQL did not catch. See giantswarm/giantswarm#36940.
+      - name: Run zizmor (non-blocking)
+        continue-on-error: true
+        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
+        with:
+          persona: regular

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 however this project does not use Semantic Versioning and there are no releases.
 Instead this file uses a date-based structure.
 
+## 2026-06-24
+
+### Security
+
+- Fixed a GitHub Actions script injection (CWE-94) in the `debug_info` "Print github context JSON" step of `create-release.yaml`, `create-release-pr.yaml`, `update-chart.yaml` and `ensure-major-version-tags.yaml`. The step interpolated `${{ toJson(github) }}` directly into a `run:` shell heredoc, so attacker-controllable event fields (e.g. a commit message containing an `EOF` line plus shell commands) could break out of the heredoc and execute arbitrary commands on the runner. The context is now passed through an `env:` variable (`GITHUB_CONTEXT`) and printed with `echo "$GITHUB_CONTEXT"`, treating it as data rather than script text — the same safe pattern already used for `COMMIT_MESSAGE` in `create-release.yaml`. Reported via giantswarm/giantswarm#36940.
+
+### Added
+
+- `validate-workflows.yaml` now runs a report-only [`zizmor`](https://github.com/zizmorcore/zizmor-action) security scan on this repository's own workflows. It uploads findings to the GitHub Security tab (code scanning) for visibility but does not block PRs (`continue-on-error: true`), so regressions of the script-injection class above are surfaced even though CodeQL did not catch them.
+
 ## 2026-06-03
 
 ### Fixed


### PR DESCRIPTION
## What

Fixes a **GitHub Actions script injection (CWE-94)** in the `debug_info` "Print github context JSON" step of four reusable workflows, and adds a report-only `zizmor` self-scan as a regression guardrail.

Reported in giantswarm/giantswarm#36940 (severity 8.8 High, confirmed with a working PoC).

## The vulnerability

The step interpolated `${{ toJson(github) }}` directly into a `run:` shell heredoc:

```yaml
- name: Print github context JSON
  run: |
    cat <<EOF
    ${{ toJson(github) }}
    EOF
```

GitHub Actions performs literal text substitution of `${{ }}` into the script **before** the shell runs it. `toJson(github)` embeds attacker-controllable fields (commit messages, PR titles/bodies, author name/email). A crafted commit message containing an `EOF` line followed by shell commands breaks out of the heredoc and runs arbitrary commands on the runner. Realistic vector: a maintainer squash-merging an external PR without editing the auto-populated commit message.

## The fix

Pass the context through an `env:` variable so the shell treats it as data, not script text — the same safe pattern already used for `COMMIT_MESSAGE` in `create-release.yaml`:

```yaml
- name: Print github context JSON
  env:
    GITHUB_CONTEXT: ${{ toJson(github) }}
  run: echo "$GITHUB_CONTEXT"
```

Applied identically to:

- `create-release.yaml`
- `create-release-pr.yaml`
- `update-chart.yaml`
- `ensure-major-version-tags.yaml`

## Guardrail (report-only)

CodeQL was enabled on this repo but did not catch this. This PR adds a non-blocking `zizmor` self-scan job to `validate-workflows.yaml` (`continue-on-error: true`) that uploads findings to the Security tab. It does **not** gate PRs on the repo's pre-existing findings; it exists to surface regressions of this class.

## Verification

- `zizmor` before → after: High `template-injection` findings dropped **31 → 27** — exactly the four `toJson(github)` sinks are gone.
- No `cat <<EOF` heredocs remain in any workflow; all `toJson(github)` now sit under `env:`.
- The new zizmor job's checkout uses `persist-credentials: false`, so it introduces no new findings.
- All edited workflow files parse as valid YAML.

## Out of scope (follow-up)

`zizmor` surfaced ~180 **pre-existing** findings: other High `template-injection` sites (branch names / inputs / `github.actor` in `run:` blocks), 21 `artipacked` checkouts missing `persist-credentials: false`, 7 `github-app`, 1 `unpinned-uses`. These are lower-severity than the merged-commit-message vector and touch working release machinery — to be addressed as a separate hardening effort. The report-only scan keeps them visible in the Security tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
