### PR TITLE
feat(yaml-diff): colourise diff output via ```diff fenced block

### DIFF
--- a/.github/workflows/yaml-diff.yaml
+++ b/.github/workflows/yaml-diff.yaml
@@ -188,7 +188,7 @@ jobs:
             section=$(mktemp)
             {
               echo
-              echo "=== ${path} ==="
+              echo "@@ ${path} @@"
               cat /tmp/yaml-diff/file-diff
             } > "${section}"
 
@@ -227,8 +227,15 @@ jobs:
               echo "<summary>Output</summary>"
               echo "<!-- mandatory empty line -->"
               echo
-              echo '```'
-              cat /tmp/yaml-diff/body
+              echo '```diff'
+              # GitHub colours a `diff` fence by line prefix: `-` red, `+` green,
+              # `@@ … @@` header. dyff go-patch prefixes changed values with an
+              # *indented* `-`/`+`; move the marker to column 0 while keeping the
+              # original indent *after* it, so the highlighter fires and nesting is
+              # still visible. The rewrite only reorders leading whitespace, so byte
+              # counts (and the truncation maths above) are unchanged. dyff colour
+              # stays off (auto-off in CI) — comments cannot render ANSI.
+              sed -E 's/^([[:space:]]*)([+-])([[:space:]].*)$/\2\1\3/' /tmp/yaml-diff/body
               echo '```'
               echo "</details>"
               echo "<!-- mandatory empty line -->"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 however this project does not use Semantic Versioning and there are no releases.
 Instead this file uses a date-based structure.
 
+## 2026-07-02
+
+### Changed
+
+- `yaml-diff.yaml` now posts its `dyff` output inside a ` ```diff ` fenced block so GitHub colourises it — removed values render red, added values green, and each file gets a `@@ … @@` header. dyff's go-patch `-`/`+` markers are moved to column 0 (indentation preserved after the marker) so the highlighter picks them up; the rewrite only reorders leading whitespace, so the comment-size truncation limits are unaffected. dyff's own ANSI colour stays disabled (comments can't render it). Requested in giantswarm/roadmap#4121.
+
 ## 2026-06-30
 
 ### Fixed


### PR DESCRIPTION
## Summary

Makes the `yaml-diff` bot's semantic diff **colourised** in the PR comment, per [giantswarm/roadmap#4121](https://github.com/giantswarm/roadmap/issues/4121) (marians: *"colour would really help to make changes stand out better"*).

GitHub PR comments can't render ANSI, so we use the ` ```diff ` code-fence highlighter instead:
- Fence changed from ` ``` ` to ` ```diff ` — GitHub renders `-` lines red, `+` lines green, `@@ … @@` as a header.
- dyff's go-patch style prefixes changed values with an **indented** `-`/`+`, which the highlighter ignores. A `sed` moves the marker to **column 0** while keeping the original indent *after* it, so nesting stays visible and the colouring fires.
- Each file's section header becomes `@@ <path> @@` for a coloured separator.

The `sed` only reorders leading whitespace → **byte counts are unchanged**, so the per-file / total truncation caps are unaffected. dyff's own ANSI colour stays off (auto-off in CI); we rely purely on GitHub highlighting.

## Before / after

Before (plain fence):
```
    - ...not encrypted atm.
    + ...not encrypted yet.
```
After (` ```diff `, markers at col 0 → red/green in the GitHub UI):
````
```diff
@@ .../configmaps/configmap.yaml @@
/data/values
  ± value change in multiline text (one insert, one deletion)
-     ...not encrypted atm.
+     ...not encrypted yet.
```
````

## Test plan

- [ ] Verified live by re-pointing gitops-template#134 (value change) and #138 (large/truncated) callers at this branch — comment renders red/green/cyan.
- [ ] Added-file note, no-diff message and `/no_diffs_printing` opt-out unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)