### PR TITLE
feat(create-release-pr): aggregate RC changelogs when promoting to stable

### DIFF
--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -271,7 +271,13 @@ jobs:
               }
               found {
                 if ($0 ~ /^\[[^]]+\]:[ \t]*https?:\/\//) next
-                print
+                if (!started && $0 ~ /^[[:space:]]*$/) next
+                started = 1
+                buf[++n] = $0
+              }
+              END {
+                while (n > 0 && buf[n] ~ /^[[:space:]]*$/) n--
+                for (i = 1; i <= n; i++) print buf[i]
               }
             ' "${changelog}"
           }
@@ -293,6 +299,21 @@ jobs:
             extract_section "${rcv}" >> "${sources}"
           done <<< "${rc_sorted}"
 
+          # The RC sources already passed validate-changelog.yaml (which accepts only the
+          # six Keep a Changelog categories), but the "Unreleased" delta -- the first
+          # source -- is not gated by that workflow (it runs only on release branches), so
+          # a non-canonical H3 there would be silently dropped by the category merge below.
+          # Refuse to drop content: fail loudly and point at the offending heading.
+          if grep -E '^### ' "${sources}" \
+            | grep -qvE '^### (Added|Changed|Deprecated|Removed|Fixed|Security)[[:space:]]*$'; then
+            echo "::error::Aggregated changelog for ${version} has a non-Keep-a-Changelog H3 heading (see below); fix it and re-run." >&2
+            echo "Allowed categories: Added, Changed, Deprecated, Removed, Fixed, Security (the Unreleased delta is not gated by validate-changelog.yaml)." >&2
+            grep -E '^### ' "${sources}" \
+              | grep -vE '^### (Added|Changed|Deprecated|Removed|Fixed|Security)[[:space:]]*$' \
+              | sed 's/^/  offending heading: /' >&2
+            exit 1
+          fi
+
           first_rc="$(printf '%s\n' "${rc_sorted}" | head -1)"
           last_rc="$(printf '%s\n' "${rc_sorted}" | tail -1)"
           if [ "${first_rc}" = "${last_rc}" ]; then
@@ -304,8 +325,8 @@ jobs:
           # Merge bullets by Keep a Changelog category, preserving insertion order
           # (Unreleased first, then RCs oldest -> newest). Emit categories in the
           # canonical order and prepend the note as the first bullet under "Changed".
-          # Non-canonical H3s cannot occur here: each RC already passed the changelog
-          # validator, which only accepts the six categories below.
+          # Every H3 here is canonical (RCs passed the validator; the Unreleased delta was
+          # checked just above), so the category merge drops no content.
           merged="$(mktemp)"
           awk -v note="${note}" '
             /^### / {
@@ -330,6 +351,15 @@ jobs:
               }
             }
           ' "${sources}" > "${merged}"
+
+          # The splice below lands the merged body inside the "## [<version>]" header that
+          # architect created. If that header is absent, the merged content would be
+          # silently discarded, leaving the changelog unchanged while this step logs
+          # success -- fail instead so the problem is visible.
+          if ! grep -qE "^## \[${core_re}\]" "${changelog}"; then
+            echo "::error::Stable section \"## [${version}]\" not found in ${changelog}; cannot splice (did 'architect prepare-release' run?)." >&2
+            exit 1
+          fi
 
           # Splice the merged content back into the "## [<version>]" section, replacing
           # only its body; the RC sections, link references and the "Unreleased" heading

--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -220,6 +220,141 @@ jobs:
       - name: Prepare release changes
         run: |
           architect prepare-release ${{ env.architect_flags }} --version "${{ needs.gather_facts.outputs.version }}"
+      - name: Aggregate release-candidate changelogs on promotion
+        env:
+          version: "${{ needs.gather_facts.outputs.version }}"
+          is_rc: "${{ needs.gather_facts.outputs.is_rc }}"
+        run: |
+          set -euo pipefail
+          changelog="CHANGELOG.md"
+          note_prefix="This release aggregates all changes from release candidate"
+
+          # Only stable releases can be a promotion of an RC series. architect has
+          # already moved the "Unreleased" delta into "## [<version>]"; for a stable
+          # promotion we additionally merge every "## [<version>-rc.N]" section into
+          # it, so the GitHub release page (built solely from the version's section)
+          # shows the complete set of changes rather than just the (often empty) delta.
+          if [ "${is_rc}" = "true" ]; then
+            echo "RC release (${version}); no aggregation needed."
+            exit 0
+          fi
+
+          if [ ! -f "${changelog}" ]; then
+            echo "No ${changelog}; nothing to aggregate."
+            exit 0
+          fi
+
+          core="${version}"
+          core_re="${core//./\\.}" # escape dots for use in a regex
+
+          # Release-candidate entries for this exact core, ordered oldest -> newest.
+          rc_sorted="$(grep -oE "^## \[${core_re}-rc\.[0-9]+\]" "${changelog}" \
+            | sed -E 's/^## \[(.*)\]$/\1/' \
+            | sort -V || true)"
+
+          if [ -z "${rc_sorted}" ]; then
+            echo "No release-candidate entries found for ${core}; not a promotion."
+            exit 0
+          fi
+
+          echo "Promotion detected for ${core}. Aggregating release candidates:"
+          echo "${rc_sorted}" | sed 's/^/  - /'
+
+          # Body of a "## [<ver>]" section: lines until the next "## [" header,
+          # skipping link-reference definitions. Mirrors the extractor in
+          # create-release.yaml so we produce exactly what the release body reads.
+          extract_section() {
+            awk -v ver="$1" '
+              /^## \[/ {
+                if (found) exit
+                if (index($0, "[" ver "]")) { found = 1; next }
+              }
+              found {
+                if ($0 ~ /^\[[^]]+\]:[ \t]*https?:\/\//) next
+                print
+              }
+            ' "${changelog}"
+          }
+
+          # Idempotency guard (defence-in-depth on top of the check_skip job): if the
+          # stable section already carries the note, this has already run.
+          if extract_section "${version}" | grep -qF "${note_prefix}"; then
+            echo "Stable section already aggregated; skipping."
+            exit 0
+          fi
+
+          # Source stream: the "Unreleased" delta (current stable section body) first,
+          # then each RC oldest -> newest. Each section begins with its own H3 headers,
+          # so simple concatenation is safe for the category bucketing below.
+          sources="$(mktemp)"
+          extract_section "${version}" >> "${sources}"
+          while IFS= read -r rcv; do
+            [ -n "${rcv}" ] || continue
+            extract_section "${rcv}" >> "${sources}"
+          done <<< "${rc_sorted}"
+
+          first_rc="$(printf '%s\n' "${rc_sorted}" | head -1)"
+          last_rc="$(printf '%s\n' "${rc_sorted}" | tail -1)"
+          if [ "${first_rc}" = "${last_rc}" ]; then
+            note="${note_prefix} ${first_rc}."
+          else
+            note="${note_prefix}s ${first_rc} through ${last_rc}."
+          fi
+
+          # Merge bullets by Keep a Changelog category, preserving insertion order
+          # (Unreleased first, then RCs oldest -> newest). Emit categories in the
+          # canonical order and prepend the note as the first bullet under "Changed".
+          # Non-canonical H3s cannot occur here: each RC already passed the changelog
+          # validator, which only accepts the six categories below.
+          merged="$(mktemp)"
+          awk -v note="${note}" '
+            /^### / {
+              cat = $0
+              sub(/^### /, "", cat)
+              sub(/[[:space:]]+$/, "", cat)
+              current = cat
+              next
+            }
+            {
+              if (current == "") next
+              if ($0 ~ /^[[:space:]]*$/) next
+              content[current] = content[current] $0 "\n"
+            }
+            END {
+              n = split("Added Changed Deprecated Removed Fixed Security", canon, " ")
+              for (i = 1; i <= n; i++) {
+                c = canon[i]
+                body = content[c]
+                if (c == "Changed") body = "- " note "\n" body
+                if (body != "") printf "### %s\n\n%s\n", c, body
+              }
+            }
+          ' "${sources}" > "${merged}"
+
+          # Splice the merged content back into the "## [<version>]" section, replacing
+          # only its body; the RC sections, link references and the "Unreleased" heading
+          # are left untouched.
+          updated="$(mktemp)"
+          awk -v ver="${version}" -v mfile="${merged}" '
+            BEGIN { while ((getline line < mfile) > 0) merged = merged line "\n" }
+            /^## \[/ {
+              if (inSection) inSection = 0
+              if (index($0, "[" ver "]")) {
+                print
+                printf "\n%s", merged
+                inSection = 1
+                next
+              }
+            }
+            inSection { next }
+            { print }
+          ' "${changelog}" > "${updated}"
+
+          mv "${updated}" "${changelog}"
+          rm -f "${sources}" "${merged}"
+
+          echo "Aggregated changelog for ${version}:"
+          extract_section "${version}"
       - name: Update version field in Chart.yaml
         run: |
           # Define chart_dir

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 however this project does not use Semantic Versioning and there are no releases.
 Instead this file uses a date-based structure.
 
+## 2026-07-09
+
+### Added
+
+- `create-release-pr.yaml` — when promoting a release candidate to a stable release (a stable version that already has `-rc.N` entries in `CHANGELOG.md`), the stable version's changelog section now aggregates all changes from its release candidates (oldest → newest) plus any `Unreleased` delta, merged by Keep a Changelog category, with a note under `### Changed`. Because a GitHub release page shows only that version's own section, the promoted stable release now lists the full set of changes instead of the (often empty) delta left after the RCs were cut.
+
 ## 2026-07-07
 
 ### Fixed


### PR DESCRIPTION
## What

When promoting a release candidate to a stable release, the stable version's `CHANGELOG.md` section now **aggregates the changelogs of all its release candidates** (oldest → newest) plus any `Unreleased` delta, merged by Keep a Changelog category, with a note under `### Changed`.

## Why

A GitHub release page shows **only that version's own changelog section**. On an RC → stable promotion, `architect prepare-release` moves just the `Unreleased` delta into `## [X.Y.Z]` — which is usually empty, since all the real changes were already recorded under the `## [X.Y.Z-rc.N]` sections. That left the promoted stable release (the one users see as "Latest release", since RCs are marked as pre-releases) showing an empty or near-empty changelog, and it also tripped `validate-changelog.yaml`'s "Empty Changelog" check.

## How

A new step, **"Aggregate release-candidate changelogs on promotion"**, runs in the `create_release_pr` job immediately after `architect prepare-release` and before the existing commit/push:

- **Promotion detection (token-agnostic):** runs only when the target is stable (`is_rc == 'false'`) **and** `CHANGELOG.md` already contains `## [X.Y.Z-rc.N]` entries for the same core version. Works for `#rc-release`, an explicit `#vX.Y.Z`, etc.
- **Merge by category:** combines the `Unreleased` delta (on top) and every RC section (oldest → newest, ordered with `sort -V`) into a single set of Keep-a-Changelog H3 sections.
- **Note:** prepends a bullet under `### Changed` — *"This release aggregates all changes from release candidate(s) X.Y.Z-rc.1 through X.Y.Z-rc.N."*
- **Preserves everything else:** the RC sections, link references and the `## [Unreleased]` heading are left untouched.

The existing commit/push carries the result into the release PR, and `create-release.yaml` reads that same section verbatim for the GitHub release body — no change needed there. `validate-changelog.yaml` also needs **no change**: the merged section always has content, so it passes as-is.

**No-op / safe cases:** RC releases, stable releases with no matching RC entries (a genuinely empty release still correctly fails validation), and re-runs (idempotent — skips if the note is already present).

## Testing

- Merge logic exercised against fixtures covering: full aggregation, idempotency, no-RC no-op, RC no-op, `sort -V` ordering (rc.1/rc.2/rc.10), and empty-stable + single RC — all produce the expected output and pass a faithful replica of the `validate-changelog.yaml` content check.
- The script extracted directly from this workflow YAML was run against a fixture and produced the expected result with RC sections and link references preserved.
- `yamllint` (repo config) and YAML parse pass.

> Note: not yet exercised in a live end-to-end release run (which needs the real `architect`/`gitsemver` binaries); recommend a promotion run in a sandbox repo before relying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
