### PR TITLE
chore(create-release-pr): bump architect to v8.3.0 (RC changelog aggregation)

### DIFF
--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -210,7 +210,7 @@ jobs:
         with:
           binary: architect
           # renovate: datasource=github-tags depName=giantswarm/architect
-          version: v8.2.1
+          version: v8.3.0
           download_url: "https://github.com/giantswarm/architect/releases/download/${version}/architect-linux-amd64"
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 however this project does not use Semantic Versioning and there are no releases.
 Instead this file uses a date-based structure.
 
+## 2026-07-14
+
+### Changed
+
+- `create-release-pr.yaml` — bumped `architect` to `v8.3.0`, which aggregates release-candidate changelogs when promoting to a stable release. On an RC → stable promotion, `architect prepare-release` now merges every `## [X.Y.Z-rc.N]` section into the promoted stable section, so the GitHub release page (built from that version's section) shows the full change set instead of the often-empty delta. No workflow logic is needed — the behavior lives in the binary that already writes `CHANGELOG.md`.
+
 ## 2026-07-07
 
 ### Fixed


### PR DESCRIPTION
## What

Bumps the pinned `architect` binary in the reusable `create-release-pr.yaml` from `v8.2.1` to **`v8.3.0`**.

## Why

architect `v8.3.0`'s `prepare-release` now **aggregates release-candidate changelogs on promotion**: on an RC → stable promotion, it merges every `## [X.Y.Z-rc.N]` section (plus the moved `Unreleased` delta) into the promoted stable section, ordered by Keep a Changelog category, with a note under `### Changed`. This makes the promoted stable GitHub release page show the full change set instead of the often-empty delta left after the RCs were cut.

The logic lives in the architect binary (giantswarm/architect#1379), which already owns `CHANGELOG.md` writing — no workflow logic needed here.

## Reaches all projects

Consumer repos run a devctl-generated thin caller (`.github/workflows/zz_generated.create_release_pr.yaml`) that references this reusable workflow at `@main`. So merging this bump makes the behavior available to **every project** on its next release run — no devctl regeneration or per-repo change required. The architect CircleCI orb is a separate artifact and is unaffected (it only does `changelog-lint`, not `prepare-release`).

## Notes

Supersedes the previously-explored in-workflow shell approach (#239, closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)