### PR TITLE
fix(workflows): stop gitsemver install from building double-v prefix

### DIFF
--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -77,8 +77,8 @@ jobs:
         with:
           binary: "gitsemver"
           # renovate: datasource=github-releases depName=giantswarm/gitsemver
-          version: 2.0.1
-          download_url: "https://github.com/giantswarm/${binary}/releases/download/v${version}/${binary}-v${version}-linux-amd64.tar.gz"
+          version: v2.0.1
+          download_url: "https://github.com/giantswarm/${binary}/releases/download/${version}/${binary}-${version}-linux-amd64.tar.gz"
           tarball_binary_path: "*/${binary}"
           smoke_test: "${binary} --version"
 

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -45,8 +45,8 @@ jobs:
         with:
           binary: "gitsemver"
           # renovate: datasource=github-releases depName=giantswarm/gitsemver
-          version: 2.0.1
-          download_url: "https://github.com/giantswarm/${binary}/releases/download/v${version}/${binary}-v${version}-linux-amd64.tar.gz"
+          version: v2.0.1
+          download_url: "https://github.com/giantswarm/${binary}/releases/download/${version}/${binary}-${version}-linux-amd64.tar.gz"
           tarball_binary_path: "*/${binary}"
           smoke_test: "${binary} --version"
       - name: Get version
@@ -115,8 +115,8 @@ jobs:
         with:
           binary: "gitsemver"
           # renovate: datasource=github-releases depName=giantswarm/gitsemver
-          version: 2.0.1
-          download_url: "https://github.com/giantswarm/${binary}/releases/download/v${version}/${binary}-v${version}-linux-amd64.tar.gz"
+          version: v2.0.1
+          download_url: "https://github.com/giantswarm/${binary}/releases/download/${version}/${binary}-${version}-linux-amd64.tar.gz"
           tarball_binary_path: "*/${binary}"
           smoke_test: "${binary} --version"
       - name: Update project.go
@@ -366,8 +366,8 @@ jobs:
         with:
           binary: "gitsemver"
           # renovate: datasource=github-releases depName=giantswarm/gitsemver
-          version: 2.0.1
-          download_url: "https://github.com/giantswarm/${binary}/releases/download/v${version}/${binary}-v${version}-linux-amd64.tar.gz"
+          version: v2.0.1
+          download_url: "https://github.com/giantswarm/${binary}/releases/download/${version}/${binary}-${version}-linux-amd64.tar.gz"
           tarball_binary_path: "*/${binary}"
           smoke_test: "${binary} --version"
       - name: Set up Go ${{ env.GO_VERSION }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 however this project does not use Semantic Versioning and there are no releases.
 Instead this file uses a date-based structure.
 
+## 2026-07-15
+
+### Fixed
+
+- `create-release.yaml` / `create-release-pr.yaml` — the `install-binary-action` step that installs `gitsemver` no longer builds a double-`v` download URL (e.g. `.../download/vv2.0.1/gitsemver-vv2.0.1-...`), which 404'd and broke the Create Release workflow for consumers. The `download_url` template hardcoded a `v` (`v${version}`), but Renovate fills the `version:` field with the `v`-prefixed release tag (`v2.0.1`), so the prefix was applied twice. The template now consumes the `v` from `${version}` (matching the neighbouring `architect` install block), so the value stays `v`-prefixed and survives future Renovate bumps. Reported in giantswarm/giantswarm#37171.
+
 ## 2026-07-14
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Instead this file uses a date-based structure.
 
 ### Fixed
 
-- `create-release.yaml` / `create-release-pr.yaml` — the `install-binary-action` step that installs `gitsemver` no longer builds a double-`v` download URL (e.g. `.../download/vv2.0.1/gitsemver-vv2.0.1-...`), which 404'd and broke the Create Release workflow for consumers. The `download_url` template hardcoded a `v` (`v${version}`), but Renovate fills the `version:` field with the `v`-prefixed release tag (`v2.0.1`), so the prefix was applied twice. The template now consumes the `v` from `${version}` (matching the neighbouring `architect` install block), so the value stays `v`-prefixed and survives future Renovate bumps. Reported in giantswarm/giantswarm#37171.
+- `create-release.yaml` / `create-release-pr.yaml` — fix a bug in the `install-binary-action` step that resulted in a double-`v` prefix in the `gitsemver` version.
 
 ## 2026-07-14
 


### PR DESCRIPTION
Renovate fills the install-binary-action `version:` field with the v-prefixed release tag (e.g. `v2.0.1`), but the gitsemver `download_url` template hardcoded another `v` (`v${version}`). The two combined into `.../download/vv2.0.1/gitsemver-vv2.0.1-linux-amd64.tar.gz`, which 404s and breaks the Create Release workflow for every consumer.

Make the template consume the `v` from `${version}` (matching the neighbouring architect install block) and keep the value `v`-prefixed, so it resolves correctly and survives future Renovate bumps. This supersedes the temporary fix in eaec78f, which set the value bare and would re-break on the next Renovate bump.

Refs giantswarm/giantswarm#37171


## Checklist

- I have updated the [CHANGELOG.md](../CHANGELOG.md) with a description of the change
