### PR TITLE
fix(ci): install gitsemver from its raw release binary

### DIFF
--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -78,8 +78,11 @@ jobs:
           binary: "gitsemver"
           # renovate: datasource=github-releases depName=giantswarm/gitsemver
           version: v2.0.1
-          download_url: "https://github.com/giantswarm/${binary}/releases/download/${version}/${binary}-${version}-linux-amd64.tar.gz"
-          tarball_binary_path: "*/${binary}"
+          # Raw binary, not the legacy `-${version}-linux-amd64.tar.gz`: those tarballs only exist
+          # for repos passing `build-release-artifacts: true` to create-release.yaml, and gitsemver
+          # stopped doing that in giantswarm/gitsemver#260. Extension-less URLs skip unarchiving,
+          # so no `tarball_binary_path` is needed.
+          download_url: "https://github.com/giantswarm/${binary}/releases/download/${version}/${binary}-linux-amd64"
           smoke_test: "${binary} --version"
 
       - name: Resolve version

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -46,8 +46,11 @@ jobs:
           binary: "gitsemver"
           # renovate: datasource=github-releases depName=giantswarm/gitsemver
           version: v2.0.1
-          download_url: "https://github.com/giantswarm/${binary}/releases/download/${version}/${binary}-${version}-linux-amd64.tar.gz"
-          tarball_binary_path: "*/${binary}"
+          # Raw binary, not the legacy `-${version}-linux-amd64.tar.gz`: those tarballs only exist
+          # for repos passing `build-release-artifacts: true` below, and gitsemver stopped doing
+          # that in giantswarm/gitsemver#260. Extension-less URLs skip unarchiving, so no
+          # `tarball_binary_path` is needed.
+          download_url: "https://github.com/giantswarm/${binary}/releases/download/${version}/${binary}-linux-amd64"
           smoke_test: "${binary} --version"
       - name: Get version
         id: get_version
@@ -116,8 +119,11 @@ jobs:
           binary: "gitsemver"
           # renovate: datasource=github-releases depName=giantswarm/gitsemver
           version: v2.0.1
-          download_url: "https://github.com/giantswarm/${binary}/releases/download/${version}/${binary}-${version}-linux-amd64.tar.gz"
-          tarball_binary_path: "*/${binary}"
+          # Raw binary, not the legacy `-${version}-linux-amd64.tar.gz`: those tarballs only exist
+          # for repos passing `build-release-artifacts: true` below, and gitsemver stopped doing
+          # that in giantswarm/gitsemver#260. Extension-less URLs skip unarchiving, so no
+          # `tarball_binary_path` is needed.
+          download_url: "https://github.com/giantswarm/${binary}/releases/download/${version}/${binary}-linux-amd64"
           smoke_test: "${binary} --version"
       - name: Update project.go
         id: update_project_go
@@ -367,8 +373,11 @@ jobs:
           binary: "gitsemver"
           # renovate: datasource=github-releases depName=giantswarm/gitsemver
           version: v2.0.1
-          download_url: "https://github.com/giantswarm/${binary}/releases/download/${version}/${binary}-${version}-linux-amd64.tar.gz"
-          tarball_binary_path: "*/${binary}"
+          # Raw binary, not the legacy `-${version}-linux-amd64.tar.gz`: those tarballs only exist
+          # for repos passing `build-release-artifacts: true` below, and gitsemver stopped doing
+          # that in giantswarm/gitsemver#260. Extension-less URLs skip unarchiving, so no
+          # `tarball_binary_path` is needed.
+          download_url: "https://github.com/giantswarm/${binary}/releases/download/${version}/${binary}-linux-amd64"
           smoke_test: "${binary} --version"
       - name: Set up Go ${{ env.GO_VERSION }}
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 however this project does not use Semantic Versioning and there are no releases.
 Instead this file uses a date-based structure.
 
+## 2026-08-05
+
+### Fixed
+
+- `create-release.yaml`, `create-release-pr.yaml` — install `gitsemver` from its raw
+  `gitsemver-linux-amd64` release asset instead of the legacy
+  `gitsemver-v<version>-linux-amd64.tar.gz`. Those tarballs are only built by this repo's own
+  `create_and_upload_build_artifacts` job, which requires the caller to pass
+  `build-release-artifacts: true` — and `giantswarm/gitsemver#260` removed that input. The pinned
+  v2.0.1 predates the removal so it still ships both asset names, but the next gitsemver release
+  would have 404'd every release workflow in the org. This is the same failure that broke
+  `schemalint`'s action at v2.6.2.
+
 ## 2026-07-29
 
 ### Fixed


### PR DESCRIPTION
Part of [giantswarm/giantswarm#37347](https://github.com/giantswarm/giantswarm/issues/37347) — *Lack of schema testing in github-workflows lets bugs pass*

Pre-emptive fix for the *same* bug that broke `giantswarm/schemalint`'s action at v2.6.2 — found while investigating that outage (#262).

## What actually caused the schemalint outage

Not the `install-binary-action` bump, and not really schemalint. The legacy
`<repo>-v<version>-<platform>.tar.gz` release assets are built by **this repo**, in
`create-release.yaml`'s `create_and_upload_build_artifacts` job — which only runs when the caller
passes `build-release-artifacts: true`.

The `chore: align files according to platform standards` template **drops that input**. Every repo
it touches silently stops publishing tarballs at its next release, while `install-binary-action`'s
default `download_url` (and every explicit tarball URL) still asks for them by name:

| repo | `build-release-artifacts` | align-files PR that dropped it | released since? |
|---|---|---|---|
| schemalint | absent | giantswarm/schemalint#319 (2026-07-29) | yes → **broke at v2.6.2** |
| **gitsemver** | **absent** | **giantswarm/gitsemver#260 (2026-06-11)** | **no — not yet** |
| architect | absent | giantswarm/architect#1325 (2026-06-17) | yes, v8.3.0 is raw-binary-only |
| helm-values-gen | `true` | — | — |
| apptestctl | `true` | — | — |

## Why this matters here

We pin `gitsemver-v${version}-linux-amd64.tar.gz` in four places. It resolves today only because
the pinned `v2.0.1` (2026-06-08) predates align-files #260 and therefore ships **both** asset
names. The next gitsemver release ships raw binaries only — and then `create-release.yaml` and
`create-release-pr.yaml` 404 for every repo in the org, since they are consumed at `@main`.

That is a much bigger blast radius than the schemalint incident, and it is armed right now.

## The change

Four `Install gitsemver` steps switch to the raw asset and drop `tarball_binary_path`
(extension-less URLs skip unarchiving — `install-binary-action` >= v3.1.0):

```diff
-          download_url: ".../${version}/${binary}-${version}-linux-amd64.tar.gz"
-          tarball_binary_path: "*/${binary}"
+          download_url: ".../${version}/${binary}-linux-amd64"
```

`create-release-pr.yaml` already installs `architect` this way, so this just makes gitsemver
consistent with it.

## Verification

No-op today, correct tomorrow — both asset names exist at the pinned v2.0.1:

```
$ curl -sSfL -o gsv https://github.com/giantswarm/gitsemver/releases/download/v2.0.1/gitsemver-linux-amd64
$ ./gsv --version
gitsemver version 2.0.1 (git: 31e7ecfa63d24e71f199d338d1ad0a6bfd0bb7fb, built: 2026-06-08T14:19:45Z)
```

The `smoke_test` is unchanged and still passes on the raw binary.

## Not changed

`apptestctl` (`gitops-validate.yaml`) keeps its tarball URL — it still passes
`build-release-artifacts: true`, so its tarball is correct today. It becomes wrong the day
align-files reaches it. The durable fix belongs in the align-files template and in
`install-binary-action`'s default URL; both are being raised upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
