### PR TITLE
Let repos define the release PR body

### DIFF
--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -297,7 +297,9 @@ jobs:
       - name: Create PR
         env:
           GITHUB_TOKEN: "${{ secrets.TAYLORBOT_GITHUB_ACTION }}"
+          actor: "${{ github.actor }}"
           base: "${{ needs.gather_facts.outputs.base }}"
+          branch: "${{ needs.gather_facts.outputs.branch }}"
           version: "${{ needs.gather_facts.outputs.version }}"
         run: |
           # A repo can ship a release PR body in .github/release-pr-body.md. It is used
@@ -313,4 +315,11 @@ jobs:
             body=""
           fi
 
-          gh pr create --assignee ${{ github.actor }} --title "chore(release): v${{ env.version }}" --body "${body}" --base ${{ env.base }} --head "${{ needs.gather_facts.outputs.branch }}"
+          # Values come from the step environment rather than template expansions, which
+          # would be interpolated into the script before it runs.
+          gh pr create \
+            --assignee "${actor}" \
+            --title "chore(release): v${version}" \
+            --body "${body}" \
+            --base "${base}" \
+            --head "${branch}"

--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -300,4 +300,17 @@ jobs:
           base: "${{ needs.gather_facts.outputs.base }}"
           version: "${{ needs.gather_facts.outputs.version }}"
         run: |
-          gh pr create --assignee ${{ github.actor }} --title "chore(release): v${{ env.version }}" --body "" --base ${{ env.base }} --head "${{ needs.gather_facts.outputs.branch }}"
+          # A repo can ship a release PR body in .github/release-pr-body.md. It is used
+          # verbatim, so a repo whose CI is triggered from the PR body - e.g. Tekton's
+          # `/run cluster-test-suites` - gets its tests run on the release PR without
+          # anyone having to remember to comment. Repos without the file keep an empty
+          # body, as before.
+          body_file=".github/release-pr-body.md"
+          if [ -f "${body_file}" ]; then
+            echo "Using release PR body from ${body_file}"
+            body="$(cat "${body_file}")"
+          else
+            body=""
+          fi
+
+          gh pr create --assignee ${{ github.actor }} --title "chore(release): v${{ env.version }}" --body "${body}" --base ${{ env.base }} --head "${{ needs.gather_facts.outputs.branch }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 however this project does not use Semantic Versioning and there are no releases.
 Instead this file uses a date-based structure.
 
+## 2026-08-06
+
+### Added
+
+- `create-release-pr`: Use `.github/release-pr-body.md` as the release PR body when a repo ships that file. Release PRs were created with an empty body, so repos whose CI is triggered from the PR body - such as Tekton's `/run cluster-test-suites` - never ran their tests on a release PR unless someone remembered to comment. Repos without the file keep an empty body. Towards https://github.com/giantswarm/roadmap/issues/4334
+
 ## 2026-08-05
 
 ### Fixed


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/4334

`create-release-pr` creates release PRs with `--body ""`. Tekton auto-runs a repo's E2E tests by reading `/run ...` from the PR body — that is how the normal PR template triggers them — so release PRs triggered nothing. Running the tests depended on someone remembering to comment, and provider chart releases were merged with no E2E run at all:

| Repo | Release PRs | E2E |
| --- | --- | --- |
| cluster-aws | #2036, #2034 | none |
| cluster-cloud-director | #577, #573 | none |
| cluster-vsphere | #527 | none |

With this change, a repo that ships `.github/release-pr-body.md` gets its contents as the release PR body. Repos without the file keep an empty body, exactly as today.

The provider chart repos will add that file containing `/run cluster-test-suites`; the pipeline already expands to **every** suite for the provider when it detects a release PR, so the extended set runs without further parameters. App repos can opt in the same way with `/run app-test-suites`.

Chosen over a central trigger with a hardcoded repo list (giantswarm/tekton-resources#930, now closed): each repo declares itself, so there is no list to maintain, repos without test suites simply do not add the file, and it is visible in the PR what will run.

The file is read from the checked-out release branch in the same job that creates the PR, so no extra checkout is needed.